### PR TITLE
chore: enable base library publishing

### DIFF
--- a/rockcraft/build.gradle.kts
+++ b/rockcraft/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    `java`
+    `java-library`
+    `maven-publish`
 }
 
 repositories {
@@ -20,4 +21,12 @@ dependencies {
 tasks.named<Test>("test") {
     // Use JUnit Jupiter for unit tests.
     useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>(project.name) {
+            from(components["java"])
+        }
+    }
 }


### PR DESCRIPTION
- base project was missing maven publication - so the common library was not published automatically. 

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
