### PR TITLE
feat: support beryx runtime plugin

### DIFF
--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/ITaskNames.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/ITaskNames.java
@@ -1,7 +1,34 @@
+/**
+ * Copyright 2024 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.canonical.rockcraft.gradle;
 
 public interface ITaskNames {
-    public String JAR = "jar";
-    public String BOOT_JAR = "bootJar";
-    public String JLINK = "jlink";
+    /**
+     * Jar task - used to package application jar by 'application' task
+     */
+    String JAR = "jar";
+    /**
+     * bootJar - used o package String Boot jar by spring boot plugin
+     */
+    String BOOT_JAR = "bootJar";
+    /**
+     * jlink task is provided by Beryx Jlink plugin
+     */
+    String JLINK = "jlink";
+
+    /***
+     * runtime task is provided by Beryx Runtime plugin
+     */
+    String RUNTIME = "runtime";
 }

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/ITaskNames.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/ITaskNames.java
@@ -19,7 +19,7 @@ public interface ITaskNames {
      */
     String JAR = "jar";
     /**
-     * bootJar - used o package String Boot jar by spring boot plugin
+     * bootJar - used to package String Boot jar by spring boot plugin
      */
     String BOOT_JAR = "bootJar";
     /**

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
@@ -23,6 +23,7 @@ public class RockSettingsFactory {
         return new RockProjectSettings("gradle", project.getName(),
             String.valueOf(project.getVersion()), project.getProjectDir().toPath(),
             project.getLayout().getBuildDirectory().getAsFile().get().toPath(),
-                !project.getTasksByName(ITaskNames.JLINK, false).isEmpty());
+                !project.getTasksByName(ITaskNames.JLINK, false).isEmpty() ||
+                        !project.getTasksByName(ITaskNames.RUNTIME, false).isEmpty());
     }
 }

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockcraftPlugin.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockcraftPlugin.java
@@ -75,11 +75,13 @@ public class RockcraftPlugin implements Plugin<Project> {
 
         Set<Task> tasks = project.getTasksByName(ITaskNames.JLINK, false);
         if (tasks.isEmpty())
+            tasks = project.getTasksByName(ITaskNames.RUNTIME, false);
+        if (tasks.isEmpty())
             tasks = project.getTasksByName(ITaskNames.BOOT_JAR, false);
         if (tasks.isEmpty())
             tasks = project.getTasksByName(ITaskNames.JAR, false);
         if (tasks.isEmpty())
-            throw new UnsupportedOperationException("Rockcraft plugin requires bootJar or jar task");
+            throw new UnsupportedOperationException("Rockcraft plugin requires jlink, runtime, bootJar or jar task");
 
         TaskProvider<PushRockcraftTask> push = project.getTasks().register("push-rock", PushRockcraftTask.class, options);
         TaskProvider<BuildRockcraftTask> build = project.getTasks().register("build-rock", BuildRockcraftTask.class, options);

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/BeryxRuntimeTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/BeryxRuntimeTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2024 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BeryxRuntimeTest extends BaseRockcraftTest {
+    protected File getJavaSource() {
+        return Paths.get(projectDir.getAbsolutePath(), "src", "main", "java", "beryxtest", "Test.java").toFile();
+    }
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        super.setUp();
+        writeString(getJavaSource(), getResource("beryx-test-class.in"));
+        writeString(getBuildFile(), getResource("beryx-runtime-project-build.in"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBeryxRuntimeRockcraft() throws IOException {
+        BuildResult result = runBuild("create-rock", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+        try (FileInputStream is = new FileInputStream(Paths.get(getProjectDir().getAbsolutePath(), "build", "rockcraft.yaml").toFile())) {
+            Yaml yaml = new Yaml();
+            Map<String, Object> parsed = yaml.load(is);
+            Map<String, Object> services = (Map<String, Object>) parsed.get("services");
+            assertTrue(services.containsKey("hello"));
+            Map<String, Object> helloService = (Map<String, Object>) services.get("hello");
+            assertEquals("/image/bin/hello", helloService.get("command"));
+
+            Map<String, Object> parts = (Map<String, Object>) parsed.get("parts");
+            Map<String, Object> dump0 = (Map<String, Object>) parts.get("gradle/rockcraft/dump0");
+            String overrideBuild = (String) dump0.get("override-build");
+            assertEquals("cp  --archive --link --no-dereference image /", overrideBuild);
+        }
+    }
+
+    /**
+     * Integration test - the rock should build successfully
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testBeryxJlinkBuild() throws IOException {
+        BuildResult result = runBuild("build-rock", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+    }
+}

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/beryx-runtime-project-build.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/beryx-runtime-project-build.in
@@ -1,0 +1,25 @@
+plugins {
+    id('org.beryx.runtime') version "1.12.5"
+    id('io.rockcrafters.rockcraft')
+}
+version = 0.01
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'beryxtest.Test'
+    }
+}
+
+application {
+    mainClass = 'beryxtest.Test'
+    applicationName = 'hello'
+}
+
+runtime {
+    modules = ['java.base']
+}
+
+rockcraft {
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -70,7 +70,9 @@ public class RockCrafter {
     protected String createRockcraft(Path root, List<File> files) throws IOException {
         ArrayList<File> filtered = new ArrayList<File>();
         for (File file : files) {
-            if (file.getName().endsWith("-plain.jar"))
+            if (file.getName().endsWith("-plain.jar")) // ignore plain jar created by Spring Boot
+                continue;
+            if (file.getName().equals("jre")) // ignore jre output created by runtime plugin
                 continue;
             filtered.add(file);
         }


### PR DESCRIPTION
Beryx [runtime](https://github.com/beryx/badass-runtime-plugin) plugin is used for non-modular applications. It needs same implementation as jlink plugin, but requires a different task name - 'runtime'.

Changes:
 - add runtime task name
 - skip 'jre' output 
 - add test for runtime plugin

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
