### PR TITLE
chore: rename plugin (gradle plugin portal reject)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           ./gradlew publishPlugins -Pgradle.publish.key=$PUBLISH_KEY -Pgradle.publish.secret=$PUBLISH_SECRET
         shell: bash
         env:
-          PUBLISH_KEY: ${{ secrets.PUBLISH_KEY }}
-          PUBLISH_SECRET: ${{ secrets.PUBLISH_SECRET }}
+          PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ To use the plugin, apply the following two steps:
 **Groovy**
 
     plugins {
-        id 'io.rockcrafters.rockcraft' version '0.1.1'
+        id 'io.github.rockcrafters.rockcraft' version '0.2.1'
     }
 
 **Kotlin**
 
     plugins {
-        id("io.rockcrafters.rockcraft") version "0.1.1"
+        id("io.github.rockcrafters.rockcraft") version "0.2.1"
     }
 
 ##### Alternatively, you can use the `buildscript` DSL:
@@ -39,10 +39,10 @@ To use the plugin, apply the following two steps:
             }
         }
         dependencies {
-            classpath 'io.rockcrafters.rockcraft:0.1.1'
+            classpath 'io.github.rockcrafters.rockcraft:0.2.1'
         }
     }
-    apply plugin: 'io.rockcrafters.rockcraft-plugin'
+    apply plugin: 'io.github.rockcrafters.rockcraft-plugin'
 
 **Kotlin**
 
@@ -53,10 +53,10 @@ To use the plugin, apply the following two steps:
             }
         }
         dependencies {
-            classpath("io.rockcrafters.rockcraft:0.1.1")
+            classpath("io.github.rockcrafters.rockcraft:0.2.1")
         }
     }
-    apply(plugin = "io.rockcrafters.rockcraft")
+    apply(plugin = "io.github.rockcrafters.rockcraft")
 
 ### 2. Configure ROCK container
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 allprojects {
-    version = "0.1.1"
-    group = "io.rockcrafters"
+    version = "0.2.1"
+    group = "io.github.rockcrafters"
 }

--- a/rockcraft-gradle/build.gradle.kts
+++ b/rockcraft-gradle/build.gradle.kts
@@ -26,7 +26,7 @@ gradlePlugin {
 
     plugins {
         create("rockcraftPlugin") {
-            id = "io.rockcrafters.rockcraft"
+            id = "io.github.rockcrafters.rockcraft"
             displayName = "Rockcraft plugin"
             description = "Plugin for rock image generation"
             implementationClass = "com.canonical.rockcraft.gradle.RockcraftPlugin"

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/alloptions.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/alloptions.in
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 version = 0.01

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/architecture.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/architecture.in
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 rockcraft {

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/beryx-project-build.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/beryx-project-build.in
@@ -1,7 +1,7 @@
 plugins {
     id('java')
     id('org.beryx.jlink') version "2.24.1"
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 version = 0.01
 

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/beryx-runtime-project-build.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/beryx-runtime-project-build.in
@@ -1,6 +1,6 @@
 plugins {
     id('org.beryx.runtime') version "1.12.5"
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 version = 0.01
 

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/build-rock-java-11.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/build-rock-java-11.in
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 rockcraft {

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/default-build.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/default-build.in
@@ -1,6 +1,6 @@
 plugins {
     id('application')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 jar {

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/rockcraft-plugin-options.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/rockcraft-plugin-options.in
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 rockcraft {

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/single-rock1.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/single-rock1.in
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 version = 0.01

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/single-rock2.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/single-rock2.in
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('io.rockcrafters.rockcraft')
+    id('io.github.rockcrafters.rockcraft')
 }
 
 version = '0.02updated'

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/spring-boot-project.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/spring-boot-project.in
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.1.6'
-    id 'io.rockcrafters.rockcraft'
+    id 'io.github.rockcrafters.rockcraft'
 }
 
 group = 'com.example'


### PR DESCRIPTION
Plugin was rejected due to invalid coordinates. 
- Update coordinates. 
- Use team publishing secret.
- Bump version

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
