### PR TITLE
fix: running app image with beryx plugins

### DIFF
--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/BeryxJLinkTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/BeryxJLinkTest.java
@@ -57,7 +57,7 @@ public class BeryxJLinkTest extends BaseRockcraftTest {
             Map<String, Object> parts = (Map<String, Object>)parsed.get("parts");
             Map<String, Object> dump0 = (Map<String, Object>)parts.get("gradle/rockcraft/dump0");
             String overrideBuild = (String) dump0.get("override-build");
-            assertEquals("cp  --archive --link --no-dereference image /", overrideBuild);
+            assertEquals("cp  --archive --link --no-dereference image ${CRAFT_PART_INSTALL}/", overrideBuild);
         }
     }
 }

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/BeryxRuntimeTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/BeryxRuntimeTest.java
@@ -56,7 +56,7 @@ public class BeryxRuntimeTest extends BaseRockcraftTest {
             Map<String, Object> parts = (Map<String, Object>) parsed.get("parts");
             Map<String, Object> dump0 = (Map<String, Object>) parts.get("gradle/rockcraft/dump0");
             String overrideBuild = (String) dump0.get("override-build");
-            assertEquals("cp  --archive --link --no-dereference image /", overrideBuild);
+            assertEquals("cp  --archive --link --no-dereference image ${CRAFT_PART_INSTALL}/", overrideBuild);
         }
     }
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -147,6 +147,7 @@ public class RockCrafter {
         part.put("source", ".");
         part.put("plugin", "nil");
         part.put("override-build", String.format("cp  --archive --link --no-dereference %s ${CRAFT_PART_INSTALL}/", image));
+        part.put("stage-packages", new String[]{"coreutils_bins", "dash_bins"});
         return part;
     }
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -167,6 +167,7 @@ public class RockCrafter {
                 Map<String, Object> serviceDefinition = new HashMap<String, Object>();
                 serviceDefinition.put("override", "replace");
                 serviceDefinition.put("summary", serviceName);
+                serviceDefinition.put("startup", "enabled");
                 serviceDefinition.put("command", String.format("/%s/bin/%s", relativeImage, serviceName));
                 services.put(serviceName, serviceDefinition);
             }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -146,7 +146,7 @@ public class RockCrafter {
         Map<String,Object> part = new HashMap<String, Object>();
         part.put("source", ".");
         part.put("plugin", "nil");
-        part.put("override-build", String.format("cp  --archive --link --no-dereference %s /", image));
+        part.put("override-build", String.format("cp  --archive --link --no-dereference %s ${CRAFT_PART_INSTALL}/", image));
         return part;
     }
 


### PR DESCRIPTION
- The application image was not copied correctly because the command missed ${CRAFT_PART_INSTALL}.
- The startup flag was not specified
- Launcher dependencies were missing

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
