### PR TITLE
fix: set up classpath in line with jlink plugin

### DIFF
--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RawRuntimePart.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RawRuntimePart.java
@@ -65,6 +65,7 @@ public class RawRuntimePart implements IRuntimeProvider {
                 "(cd ${CRAFT_PART_BUILD}/tmp && for jar in ${PROCESS_JARS}; do jar xvf ${jar}; done;)"
         );
         append(commands, "CPATH=$(find ${CRAFT_PART_BUILD}/tmp -type f -name *.jar)");
+        append(commands, "CPATH=$(CPATH):$(find ${CRAFT_STAGE} -type f -name *.jar)");
         append(commands, "CPATH=$(echo ${CPATH}:. | sed s'/[[:space:]]/:/'g)");
         append(commands, "echo ${CPATH}");
         append(commands, "if [ \"x${PROCESS_JARS}\" != \"x\" ]; then");

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/RawRunimePartTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/RawRunimePartTest.java
@@ -56,4 +56,15 @@ public class RawRunimePartTest {
         assertEquals("openjdk-11-jdk", ret[0]);
         assertTrue(code.get("override-build").toString().contains("--multi-release 8"));
     }
+
+    @Test
+    void rawRuntimeMultipleJars() {
+        RockcraftOptions options = new RockcraftOptions();
+        RawRuntimePart part = new RawRuntimePart(options);
+        Map<String, Object> code = part.getRuntimePart(input);
+        // classpath should contain both embeeded jars from the boot jar and every jar found in the jar directory
+        // to avoid building incomplete runtime if the dependencies are packaged separately
+        assertTrue(code.get("override-build").toString().contains("CPATH=$(find ${CRAFT_PART_BUILD}/tmp -type f -name *.jar)"));
+        assertTrue(code.get("override-build").toString().contains("CPATH=$(CPATH):$(find ${CRAFT_STAGE} -type f -name *.jar)"));
+    }
 }


### PR DESCRIPTION
JLink rockcraft plugin adds all jars found in staging area to jlink arguments. Since we know artifact in maven/gradle plugin it is sufficient to add them to the classpath.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
