### PR TITLE
chore: enable maven publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Java
-        run: |
-          sudo apt-get install -y openjdk-8-jdk-headless
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v4
+        with: # running setup-java again overwrites the settings.xml
+          distribution: 'temurin'
+          java-version: '8'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main
@@ -61,6 +68,11 @@ jobs:
       - name: Build and verify maven project
         run: |
           mvn -B install invoker:install invoker:run
+        env:
+          MAVEN_USERNAME: do-not-deploy
+          MAVEN_CENTRAL_TOKEN: do-not-deploy
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+
 
   build-gradle:
     name: Build Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '8'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main
@@ -38,6 +44,16 @@ jobs:
         env:
           PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+      - name: Publish to Maven central
+        id: deploy-maven
+        run: |
+          mvn deploy -B
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <distributionManagement>
-        <snapshotRepository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <modules>
         <module>rockcraft</module>
@@ -32,6 +22,60 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.10.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.6.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <properties>
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/AbstractRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/AbstractRockMojo.java
@@ -22,7 +22,17 @@ import org.apache.maven.project.MavenProject;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AbstractRockMojo extends AbstractMojo {
+/**
+ * A base class for all rock mojos that initializes
+ * RockcraftOptions
+ */
+public abstract class AbstractRockMojo extends AbstractMojo {
+
+    /**
+     * No specific initialization
+     */
+    public AbstractRockMojo() {}
+
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
@@ -61,14 +71,28 @@ public class AbstractRockMojo extends AbstractMojo {
 
     private RockcraftOptions options = new RockcraftOptions();
 
+    /**
+     * Returns RockCraftOptions initialized using plugin options
+     *
+     * @return initialized plugin options
+     */
     protected RockcraftOptions getOptions() {
         return options;
     }
 
+    /**
+     * Returns current Maven project
+     *
+     * @return Maven Project object
+     */
     protected MavenProject getProject() {
         return project;
     }
 
+    /**
+     * Executes mojo. Initializes RockcraftOptions using plugin
+     * configuration
+     */
     @Override
     public void execute() throws MojoExecutionException {
         options.setBuildPackage(buildPackage);

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/BuildRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/BuildRockMojo.java
@@ -20,9 +20,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.IOException;
 
+/**
+ * Builds rock image
+ */
 @Mojo(name = "build-rock", threadSafe = false, requiresProject = true, defaultPhase = LifecyclePhase.INSTALL)
 public class BuildRockMojo extends AbstractRockMojo {
 
+    /**
+     * No specific initialization
+     */
+    public BuildRockMojo(){}
+
+    /**
+     * Executes mojo to build the rock image
+     */
     public void execute() throws MojoExecutionException {
         super.execute();
         try {

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/CreateRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/CreateRockMojo.java
@@ -22,9 +22,20 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
+/**
+ * Writes rockcraft file to the output directory
+ */
 @Mojo(name = "create-rock", threadSafe = false, requiresProject = true, defaultPhase = LifecyclePhase.PACKAGE)
 public class CreateRockMojo extends AbstractRockMojo {
 
+    /**
+     * No specific initialization
+     */
+    public CreateRockMojo(){}
+
+    /**
+     * Executes mojo: writes rockcraft file to the output directory
+     */
     @Override
     public void execute() throws MojoExecutionException {
         super.execute();

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/PushRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/PushRockMojo.java
@@ -20,8 +20,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.IOException;
 
+/**
+ * Pushes rock image to the local docker daemon
+ */
 @Mojo(name = "push-rock", threadSafe = false, requiresProject = true, defaultPhase = LifecyclePhase.INSTALL)
 public class PushRockMojo extends AbstractRockMojo {
+
+    /**
+     * No specific initialization
+     */
+    public PushRockMojo(){}
+
+    /**
+     * Executes mojo: pushes existing rock file to the docker daemon
+     */
     public void execute() throws MojoExecutionException {
         super.execute();
         try {

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockBuilder.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockBuilder.java
@@ -51,6 +51,7 @@ public class RockBuilder {
      * Pushes rock image to the docker
      *
      * @param settings - rockcraft project settings
+     * @param options = rockcraft options
      * @throws IOException          - IO error while writing <i>rockcraft.yaml</i>
      * @throws InterruptedException - <i>rockcraft</i> process was aborted
      */
@@ -70,6 +71,7 @@ public class RockBuilder {
      * Builds the rock image
      *
      * @param settings - rockcraft project settings
+     * @param options - rockcraft options
      * @throws IOException          - IO error while writing <i>rockcraft.yaml</i>
      * @throws InterruptedException - <i>rockcraft</i> process was aborted
      */

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
@@ -21,6 +21,7 @@ public class RockProjectSettings {
      * @param version       rockcraft project version
      * @param projectPath   path to the rockcraft project
      * @param rockOutput    path to where to generate rockcraft.yaml
+     * @param beryxJlink    whether to copy Beryx jlink image to the rock
      */
     public RockProjectSettings(String generatorName, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
         this.generatorName = generatorName;
@@ -33,6 +34,8 @@ public class RockProjectSettings {
 
     /**
      * Get the generator name
+     *
+     * @return generator name
      */
     public String getGeneratorName() {
         return generatorName;

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
@@ -238,7 +238,7 @@ public class RockcraftOptions {
     /**
      * Sets the path to rockcraft.yaml file
      *
-     * @param description - description file
+     * @param rockcraftYaml - rockcraft yaml file
      */
     public void setRockcraftYaml(String rockcraftYaml) {
         if (rockcraftYaml != null) {

--- a/rockcraft/src/main/java/com/canonical/rockcraft/util/MapMerger.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/util/MapMerger.java
@@ -22,6 +22,12 @@ import java.util.function.BiFunction;
  * It is used to combine Yaml files
  */
 public class MapMerger {
+
+    /**
+     * No specific initialization
+     */
+    public MapMerger(){}
+
     /**
      * Recursively merges two map of maps
      *


### PR DESCRIPTION
This PR enables maven central publishing workflow.

Changes:
 - Add missing javadoc comments 
 - Enable javadoc and sources packaging for maven plugin
 - Add maven central publishing plugin
 - Enable gpg signing
 - Add release workflow step for maven
 - Remove `release` property as it was interfering with javadoc generation using Java 8.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
