### PR TITLE
chore: ensure consistent publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.source>8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
     </properties>
 
 
@@ -21,6 +22,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/rockcraft-gradle/build.gradle.kts
+++ b/rockcraft-gradle/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "1.3.0"
+    id ("org.gradlex.reproducible-builds") version "1.0"
 }
 
 repositories {

--- a/rockcraft-maven/pom.xml
+++ b/rockcraft-maven/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.rockcrafters</groupId>
-            <artifactId>rockcraft</artifactId>
+            <artifactId>rockcraft-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/rockcraft/build.gradle.kts
+++ b/rockcraft/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-library`
     `maven-publish`
+    id ("org.gradlex.reproducible-builds") version "1.0"
 }
 
 repositories {

--- a/rockcraft/pom.xml
+++ b/rockcraft/pom.xml
@@ -6,7 +6,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>rockcraft</artifactId>
+    <artifactId>rockcraft-common</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
We need to ensure that building from source will produce the same binaries:
- name maven and gradle rockcraft library differently to avoid mismatching binaries
- enable reproducible builds for maven
- enable reproducible builds for gradle
- explicitly call out jar plugin version to ensure that correct version is pulled in

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
