### PR TITLE
fix: use shadow jar to package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ To use the plugin, apply the following two steps:
 **Groovy**
 
     plugins {
-        id 'io.github.rockcrafters.rockcraft' version '0.2.1'
+        id 'io.github.rockcrafters.rockcraft' version '0.2.2'
     }
 
 **Kotlin**
 
     plugins {
-        id("io.github.rockcrafters.rockcraft") version "0.2.1"
+        id("io.github.rockcrafters.rockcraft") version "0.2.2"
     }
 
 ##### Alternatively, you can use the `buildscript` DSL:
@@ -73,7 +73,7 @@ To use the plugin, apply the following two steps:
             }
         }
         dependencies {
-            classpath 'io.github.rockcrafters.rockcraft:0.2.1'
+            classpath 'io.github.rockcrafters.rockcraft:0.2.2'
         }
     }
     apply plugin: 'io.github.rockcrafters.rockcraft-plugin'
@@ -87,7 +87,7 @@ To use the plugin, apply the following two steps:
             }
         }
         dependencies {
-            classpath("io.github.rockcrafters.rockcraft:0.2.1")
+            classpath("io.github.rockcrafters.rockcraft:0.2.2")
         }
     }
     apply(plugin = "io.github.rockcrafters.rockcraft")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 allprojects {
-    version = "0.2.1"
+    version = "0.2.2"
     group = "io.github.rockcrafters"
     apply(plugin = "maven-publish")
     plugins.withType<MavenPublishPlugin>().configureEach {

--- a/examples/gradle/app-options/build.gradle
+++ b/examples/gradle/app-options/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('application')
-    id('io.github.rockcrafters.rockcraft') version "0.2.1"
+    id('io.github.rockcrafters.rockcraft') version "0.2.2"
 }
 version = 0.01
 

--- a/examples/gradle/beryx-jlink/build.gradle
+++ b/examples/gradle/beryx-jlink/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('org.beryx.jlink') version "2.24.1"
-    id('io.github.rockcrafters.rockcraft') version "0.2.1"
+    id('io.github.rockcrafters.rockcraft') version "0.2.2"
 }
 version = 0.01
 

--- a/examples/gradle/beryx-runtime/build.gradle
+++ b/examples/gradle/beryx-runtime/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('org.beryx.runtime') version "1.12.5"
-    id('io.github.rockcrafters.rockcraft') version "0.2.1"
+    id('io.github.rockcrafters.rockcraft') version "0.2.2"
 }
 version = 0.01
 

--- a/examples/gradle/spring-app/build.gradle
+++ b/examples/gradle/spring-app/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.6'
-	id 'io.github.rockcrafters.rockcraft' version '0.2.1'
+	id 'io.github.rockcrafters.rockcraft' version '0.2.2'
 }
 
 group = 'com.example'

--- a/examples/maven/custom-rockcraft/pom.xml
+++ b/examples/maven/custom-rockcraft/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>io.github.rockcrafters</groupId>
                 <artifactId>rockcraft-maven-plugin</artifactId>
-                <version>0.2.1</version>
+                <version>0.2.2</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/examples/maven/shaded-jar/pom.xml
+++ b/examples/maven/shaded-jar/pom.xml
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>io.github.rockcrafters</groupId>
                 <artifactId>rockcraft-maven-plugin</artifactId>
-                <version>0.2.1</version>
+                <version>0.2.2</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/examples/maven/spring-boot-app/pom.xml
+++ b/examples/maven/spring-boot-app/pom.xml
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>io.github.rockcrafters</groupId>
                 <artifactId>rockcraft-maven-plugin</artifactId>
-                <version>0.2.1</version>
+                <version>0.2.2</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.rockcrafters</groupId>
     <artifactId>rockcraft-parent</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
     <packaging>pom</packaging>
     <properties>
         <maven.compiler.target>8</maven.compiler.target>

--- a/rockcraft-gradle/build.gradle.kts
+++ b/rockcraft-gradle/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("com.gradleup.shadow") version "8.3.3"
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "1.3.0"
     id ("org.gradlex.reproducible-builds") version "1.0"
@@ -7,6 +8,10 @@ plugins {
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
+}
+
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+   archiveClassifier.set("")
 }
 
 dependencies {

--- a/rockcraft-maven/pom.xml
+++ b/rockcraft-maven/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.github.rockcrafters</groupId>
         <artifactId>rockcraft-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
     </parent>
 
     <packaging>maven-plugin</packaging>

--- a/rockcraft/pom.xml
+++ b/rockcraft/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.github.rockcrafters</groupId>
         <artifactId>rockcraft-parent</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
- main library (rockcraft) is not yet published anywhere so it is impossible to reference it from the plugin. 
This makes version 0.2.1 unusable. 

Changes:
 - bump version to 0.2.2
 - apply shadow jar plugin

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
