### PR TITLE
chore: run apt update before install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
 
       - name: Setup Java
         run: |
+          sudo apt-get update
           sudo apt-get install -y openjdk-8-jdk-headless
 
       - name: Setup LXD


### PR DESCRIPTION
Changes:
 - run apt update before installing openjdk-8 package.
 
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
