### PR TITLE
chore: extract common options for rockcraft settings

### DIFF
--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
@@ -1,7 +1,9 @@
 package com.canonical.rockcraft.gradle;
 
-import com.canonical.rockcraft.builder.RockProjectSettings;
 import org.gradle.api.Project;
+
+import com.canonical.rockcraft.builder.Generator;
+import com.canonical.rockcraft.builder.RockProjectSettings;
 
 /**
  * Creates RockProjectSettings from Gradle project
@@ -20,7 +22,7 @@ public class RockSettingsFactory {
      * @return RockProjectSettings
      */
     public static final RockProjectSettings createRockProjectSettings(Project project) {
-        return new RockProjectSettings("gradle", project.getName(),
+        return new RockProjectSettings(Generator.gradle, project.getName(),
             String.valueOf(project.getVersion()), project.getProjectDir().toPath(),
             project.getLayout().getBuildDirectory().getAsFile().get().toPath(),
                 !project.getTasksByName(ITaskNames.JLINK, false).isEmpty() ||

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/AbstractRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/AbstractRockMojo.java
@@ -13,6 +13,7 @@
  */
 package com.canonical.rockcraft.maven;
 
+import com.canonical.rockcraft.builder.RockArchitecture;
 import com.canonical.rockcraft.builder.RockcraftOptions;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -61,7 +62,7 @@ public abstract class AbstractRockMojo extends AbstractMojo {
     private String branch;
 
     @Parameter(property = "architectures")
-    private RockcraftOptions.RockArchitecture[] architectures = new RockcraftOptions.RockArchitecture[0];
+    private RockArchitecture[] architectures = new RockArchitecture[0];
 
     @Parameter(property = "slices")
     private List<String> slices = new ArrayList<String>();

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
@@ -13,6 +13,7 @@
  */
 package com.canonical.rockcraft.maven;
 
+import com.canonical.rockcraft.builder.Generator;
 import com.canonical.rockcraft.builder.RockProjectSettings;
 import org.apache.maven.project.MavenProject;
 
@@ -33,7 +34,7 @@ public class RockSettingsFactory {
      * @return RockProjectSettings
      */
     public static final RockProjectSettings createRockProjectSettings(MavenProject project) {
-        return new RockProjectSettings("maven", project.getName(),
+        return new RockProjectSettings(Generator.maven, project.getName(),
                 project.getVersion(), project.getBasedir().getAbsoluteFile().toPath(),
                 project.getArtifact().getFile().getParentFile().toPath(),
                 false);

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractRockCrafter {
+    protected final RockProjectSettings settings;
+    protected final RockcraftOptions options;
+    protected final List<File> artifacts;
+
+    public AbstractRockCrafter(RockProjectSettings settings, RockcraftOptions options, List<File> artifacts) {
+        this.settings = settings;
+        this.options = options;
+        this.artifacts = artifacts;
+    }
+
+    protected List<File> getArtifacts() { return artifacts; }
+
+    protected RockProjectSettings getSettings() { return settings; }
+
+    public abstract void writeRockcraft() throws IOException;
+
+    protected Map<String, Object> getPlatforms() {
+        HashMap<String, Object> arches = new HashMap<String, Object>();
+        for (RockArchitecture a : getOptions().getArchitectures())
+            arches.put(String.valueOf(a), "");
+        if (arches.isEmpty())
+            arches.put("amd64", "");
+        return arches;
+    }
+
+    protected RockcraftOptions getOptions() {
+        return options;
+    }
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
@@ -13,8 +13,11 @@
  */
 package com.canonical.rockcraft.builder;
 
+import org.yaml.snakeyaml.Yaml;
+
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -84,5 +87,18 @@ public abstract class AbstractRockCrafter {
         rockcraft.put("base", "bare");
         rockcraft.put("build-base", "ubuntu@24.04");
         return rockcraft;
+    }
+
+    protected Map<String, Object> loadRockcraftSnippet(Yaml yaml) throws IOException {
+        Map<String, Object> rockcraftYaml = new HashMap<String, Object>();
+        if (getOptions().getRockcraftYaml() != null) {
+            File rockcraftFile = getSettings().getProjectPath().resolve(getOptions().getRockcraftYaml()).toFile();
+            if (!rockcraftFile.exists())
+                throw new UnsupportedOperationException("Rockcraft file does not exist.");
+            try (FileInputStream is = new FileInputStream(rockcraftFile)) {
+                rockcraftYaml = yaml.load(is);
+            }
+        }
+        return rockcraftYaml;
     }
 }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
@@ -21,10 +21,10 @@ import java.util.Map;
 
 public abstract class AbstractRockCrafter {
     protected final RockProjectSettings settings;
-    protected final RockcraftOptions options;
+    protected final CommonRockcraftOptions options;
     protected final List<File> artifacts;
 
-    public AbstractRockCrafter(RockProjectSettings settings, RockcraftOptions options, List<File> artifacts) {
+    public AbstractRockCrafter(RockProjectSettings settings, CommonRockcraftOptions options, List<File> artifacts) {
         this.settings = settings;
         this.options = options;
         this.artifacts = artifacts;
@@ -45,7 +45,7 @@ public abstract class AbstractRockCrafter {
         return arches;
     }
 
-    protected RockcraftOptions getOptions() {
+    protected CommonRockcraftOptions getOptions() {
         return options;
     }
 }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/CommonRockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/CommonRockcraftOptions.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides common options for rockcraft.yaml generation
+ */
+public class CommonRockcraftOptions {
+    private String buildPackage = "openjdk-21-jdk";
+    private String summary = "";
+    private Path description = null;
+    private String source;
+    private String branch;
+    private RockArchitecture[] architectures = new RockArchitecture[0];
+    private List<String> slices = new ArrayList<String>();
+    private Path rockcraftYaml = null;
+
+    /**
+     * Get the Ubuntu OpenJDK package used to build the runtime image
+     *
+     * @return package name
+     */
+    public String getBuildPackage() {
+        return buildPackage;
+    }
+
+    /**
+     * Set the OpenJDK package used to build the runtime image
+     *
+     * @param buildPackage - Ubuntu package name
+     */
+    public void setBuildPackage(String buildPackage) {
+        this.buildPackage = buildPackage;
+    }
+
+    /**
+     * Gets <i>chisel-releases</i> branch
+     *
+     * @return <i>chisel-releases</i> branch
+     */
+    public String getBranch() {
+        return branch;
+    }
+
+    /**
+     * Sets <i>chisel-releases</i> branch
+     *
+     * @param branch - git branch
+     */
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    /**
+     * Gets the summary comment for the ROCK
+     *
+     * @return summary comment
+     */
+    public String getSummary() {
+        return summary;
+    }
+
+    /**
+     * Sets the summary comment for the ROCK
+     *
+     * @param summary - summary comment
+     */
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    /**
+     * Gets a description file for the ROCK
+     *
+     * @return path to the description
+     */
+    public Path getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the path to the description file
+     *
+     * @param description - description file
+     */
+    public void setDescription(String description) {
+        if (description != null) {
+            this.description = Paths.get(description);
+        }
+    }
+
+    /**
+     * Gets the list of the supported architectures
+     *
+     * @return supported architectures
+     */
+    public RockArchitecture[] getArchitectures() {
+        return architectures;
+    }
+
+    /**
+     * Sets the list of the supported architectures
+     *
+     * @param architectures - supported architectures
+     */
+    public void setArchitectures(RockArchitecture[] architectures) {
+        this.architectures = architectures;
+    }
+
+    /**
+     * Get chisel slices to install
+     *
+     * @return list of the slice names
+     */
+    public List<String> getSlices() {
+        return slices;
+    }
+
+    /**
+     * Overrides chisel slices to install
+     *
+     * @param slices - list of chisel slices
+     */
+    public void setSlices(List<String> slices) {
+        this.slices = slices;
+    }
+
+    /**
+     * Get Git repository URL of the <i>chisel-releases</i>
+     *
+     * @return Git repository URL
+     */
+    public String getSource() {
+        return source;
+    }
+
+    /**
+     * Override <i>chisel-releases</i> repository URL
+     *
+     * @param source - Git repository URL
+     */
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    /**
+     * Get path to the optional rockcraft.yaml
+     *
+     * @return path to rockcraft yaml
+     */
+    public Path getRockcraftYaml() {
+        return rockcraftYaml;
+    }
+
+    /**
+     * Sets the path to rockcraft.yaml file
+     *
+     * @param rockcraftYaml - rockcraft yaml file
+     */
+    public void setRockcraftYaml(String rockcraftYaml) {
+        if (rockcraftYaml != null) {
+            this.rockcraftYaml = Paths.get(rockcraftYaml);
+        }
+    }
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/Generator.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/Generator.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+public enum Generator {
+    maven,
+    gradle
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockArchitecture.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockArchitecture.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+/**
+ * The list of supported Ubuntu architectures
+ */
+public enum RockArchitecture {
+    /**
+     * AMD64
+     */
+    amd64,
+    /**
+     * ARM64
+     */
+    arm64,
+    /**
+     * ARM hard float
+     */
+    armhf,
+    /**
+     * I386
+     */
+    i386,
+    /**
+     * PowerPC 64 EL
+     */
+    ppc64el,
+    /**
+     * RISCV
+     */
+    riscv64,
+    /**
+     * S390X
+     */
+    s390x
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -199,7 +199,7 @@ public class RockCrafter {
         return services;
     }
 
-    private Map<String, Object> getPlatforms() {
+    protected Map<String, Object> getPlatforms() {
         HashMap<String, Object> archs = new HashMap<String, Object>();
         for (RockArchitecture a : getOptions().getArchitectures())
             archs.put(String.valueOf(a), "");

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -197,7 +197,7 @@ public class RockCrafter {
 
     private Map<String, Object> getPlatforms() {
         HashMap<String, Object> archs = new HashMap<String, Object>();
-        for (RockcraftOptions.RockArchitecture a : getOptions().getArchitectures())
+        for (RockArchitecture a : getOptions().getArchitectures())
             archs.put(String.valueOf(a), "");
         if (archs.isEmpty())
             archs.put("amd64", "");

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -18,7 +18,6 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.*;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -44,19 +43,6 @@ public class RockCrafter extends AbstractRockCrafter {
     }
 
     /**
-     * Writes a rockcraft.yaml file to the output directory
-     *
-     * @throws IOException - the method fails to write rockcraft.yaml
-     */
-    @Override
-    public void writeRockcraft() throws IOException {
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(getSettings().getRockOutput().resolve(IRockcraftNames.ROCKCRAFT_YAML).toFile()))) {
-            String rockcraft = createRockcraft(getSettings().getRockOutput(), getArtifacts());
-            writer.write(rockcraft);
-        }
-    }
-
-    /**
      * Generate content of the <i>rockcraft.yaml</i>
      *
      * @param root  - location of build directory
@@ -64,6 +50,7 @@ public class RockCrafter extends AbstractRockCrafter {
      * @return content of the <i>rockcraft.yaml</i>
      * @throws IOException - IO error writing <i>rockcraft.yaml</i>
      */
+    @Override
     protected String createRockcraft(Path root, List<File> files) throws IOException {
         RockcraftOptions options = (RockcraftOptions)getOptions();
         ArrayList<File> filtered = new ArrayList<File>();
@@ -79,23 +66,7 @@ public class RockCrafter extends AbstractRockCrafter {
             relativeOutputs.add(root.relativize(file.toPath()).toString());
         }
 
-        Map<String, Object> rockcraft = new HashMap<String, Object>();
-        rockcraft.put(IRockcraftNames.ROCKCRAFT_NAME, getSettings().getName());
-        rockcraft.put(IRockcraftNames.ROCKCRAFT_VERSION, String.valueOf(getSettings().getVersion()));
-        rockcraft.put("summary", getOptions().getSummary());
-        Path description = getOptions().getDescription();
-        if (description != null) {
-            File descriptionFile = getSettings().getProjectPath().resolve(description).toFile();
-            if (!descriptionFile.exists())
-                throw new UnsupportedOperationException("Rockcraft plugin description file does not exist.");
-            rockcraft.put("description", new String(Files.readAllBytes(descriptionFile.toPath())));
-        } else {
-            rockcraft.put("description", "");
-        }
-
-        rockcraft.put("platforms", getPlatforms());
-        rockcraft.put("base", "bare");
-        rockcraft.put("build-base", "ubuntu@24.04");
+        Map<String, Object> rockcraft = createCommonSection();
 
         DumperOptions dumperOptions = new DumperOptions();
         dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -72,15 +72,7 @@ public class RockCrafter extends AbstractRockCrafter {
         dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         Yaml yaml = new Yaml(dumperOptions);
 
-        Map<String, Object> rockcraftYaml = new HashMap<String, Object>();
-        if (getOptions().getRockcraftYaml() != null) {
-            File rockcraftFile = getSettings().getProjectPath().resolve(getOptions().getRockcraftYaml()).toFile();
-            if (!rockcraftFile.exists())
-                throw new UnsupportedOperationException("Rockcraft file does not exist.");
-            try (FileInputStream is = new FileInputStream(rockcraftFile)) {
-                rockcraftYaml = yaml.load(is);
-            }
-        }
+        Map<String, Object> rockcraftYaml = loadRockcraftSnippet(yaml);
 
         Map<String, Object> rockParts = (Map<String, Object>) rockcraftYaml.get("parts");
         Map<String, Object> rockServices = (Map<String, Object>) rockcraftYaml.get("services");

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -29,15 +29,8 @@ import java.util.Map;
 /**
  * Creates a rockcraft.yaml based on RockOptions
  */
-public class RockCrafter {
+public class RockCrafter extends AbstractRockCrafter {
 
-    private final RockProjectSettings settings;
-    private final RockcraftOptions options;
-    private final List<File> artifacts;
-
-
-    protected List<File> getArtifacts() { return artifacts; }
-    protected RockProjectSettings getSettings() { return settings; }
 
     /**
      * Creates RockCrafter
@@ -47,9 +40,7 @@ public class RockCrafter {
      * @param artifacts - list of artifacts to package
      */
     public RockCrafter(RockProjectSettings settings, RockcraftOptions options, List<File> artifacts) {
-        this.settings = settings;
-        this.options = options;
-        this.artifacts = artifacts;
+        super(settings, options, artifacts);
     }
 
     /**
@@ -57,6 +48,7 @@ public class RockCrafter {
      *
      * @throws IOException - the method fails to write rockcraft.yaml
      */
+    @Override
     public void writeRockcraft() throws IOException {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(getSettings().getRockOutput().resolve(IRockcraftNames.ROCKCRAFT_YAML).toFile()))) {
             String rockcraft = createRockcraft(getSettings().getRockOutput(), getArtifacts());
@@ -198,16 +190,6 @@ public class RockCrafter {
         }
         return services;
     }
-
-    protected Map<String, Object> getPlatforms() {
-        HashMap<String, Object> archs = new HashMap<String, Object>();
-        for (RockArchitecture a : getOptions().getArchitectures())
-            archs.put(String.valueOf(a), "");
-        if (archs.isEmpty())
-            archs.put("amd64", "");
-        return archs;
-    }
-
     /**
      * Return list of the chisel slices
      */
@@ -315,7 +297,4 @@ public class RockCrafter {
         return services;
     }
 
-    protected RockcraftOptions getOptions() {
-        return options;
-    }
 }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -65,6 +65,7 @@ public class RockCrafter extends AbstractRockCrafter {
      * @throws IOException - IO error writing <i>rockcraft.yaml</i>
      */
     protected String createRockcraft(Path root, List<File> files) throws IOException {
+        RockcraftOptions options = (RockcraftOptions)getOptions();
         ArrayList<File> filtered = new ArrayList<File>();
         for (File file : files) {
             if (file.getName().endsWith("-plain.jar")) // ignore plain jar created by Spring Boot
@@ -122,7 +123,7 @@ public class RockCrafter extends AbstractRockCrafter {
         yamlOutput.append("\n");
         rockcraft.clear();
 
-        if (getOptions().isCreateService()) {
+        if (options.isCreateService()) {
             if (getSettings().getBeryxJLink()) {
                 rockcraft.put("services", MapMerger.merge(getImageProjectService(root, filtered), rockServices));
             } else {
@@ -221,7 +222,8 @@ public class RockCrafter extends AbstractRockCrafter {
     }
 
     private Map<String, Object> getProjectParts(List<File> files, List<String> relativeJars) {
-        IRuntimeProvider provider = getOptions().getJlink() ? new JLinkRuntimePart(getOptions()) : new RawRuntimePart(getOptions());
+        RockcraftOptions options = (RockcraftOptions) getOptions();
+        IRuntimeProvider provider = options.getJlink() ? new JLinkRuntimePart(options) : new RawRuntimePart(options);
         HashMap<String, Object> parts = new HashMap<String, Object>();
         parts.put(getSettings().getGeneratorName() + "/rockcraft/dump", getDumpPart(relativeJars));
         Map<java.lang.String,java.lang.Object> runtimePart = provider.getRuntimePart(files);
@@ -272,7 +274,7 @@ public class RockCrafter extends AbstractRockCrafter {
     }
 
     private Map<String, Object> getProjectService(List<String> relativeJars) {
-        String command = getOptions().getCommand();
+        String command = ((RockcraftOptions)getOptions()).getCommand();
         if (command == null || command.trim().isEmpty()) {
             if (relativeJars.size() == 1) {
                 command = String.format("/usr/bin/java -jar /jars/%s", Paths.get(relativeJars.iterator().next()).getFileName().toString());

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
@@ -9,7 +9,7 @@ public class RockProjectSettings {
     private final String name;
     private final String version;
     private final Path projectPath;
-    private final String generatorName;
+    private final Generator generatorName;
     private final Path rockOutput;
     private final boolean beryxJlink;
 
@@ -23,7 +23,7 @@ public class RockProjectSettings {
      * @param rockOutput    path to where to generate rockcraft.yaml
      * @param beryxJlink    whether to copy Beryx jlink image to the rock
      */
-    public RockProjectSettings(String generatorName, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
+    public RockProjectSettings(Generator generatorName, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
         this.generatorName = generatorName;
         this.name = name;
         this.version = version;
@@ -37,7 +37,7 @@ public class RockProjectSettings {
      *
      * @return generator name
      */
-    public String getGeneratorName() {
+    public Generator getGeneratorName() {
         return generatorName;
     }
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
@@ -264,37 +264,4 @@ public class RockcraftOptions {
         this.createService = createService;
     }
 
-    /**
-     * The list of supported Ubuntu architectures
-     */
-    public enum RockArchitecture {
-        /**
-         * AMD64
-         */
-        amd64,
-        /**
-         * ARM64
-         */
-        arm64,
-        /**
-         * ARM hard float
-         */
-        armhf,
-        /**
-         * I386
-         */
-        i386,
-        /**
-         * PowerPC 64 EL
-         */
-        ppc64el,
-        /**
-         * RISCV
-         */
-        riscv64,
-        /**
-         * S390X
-         */
-        s390x
-    }
 }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
@@ -13,27 +13,14 @@
  */
 package com.canonical.rockcraft.builder;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Rockcraft.yaml generation options
  */
-public class RockcraftOptions {
+public class RockcraftOptions extends CommonRockcraftOptions {
 
-    private String buildPackage = "openjdk-21-jdk";
     private int targetRelease = 21;
     private boolean jlink = false;
-    private String summary = "";
-    private Path description = null;
     private String command = "";
-    private String source;
-    private String branch;
-    private RockArchitecture[] architectures = new RockArchitecture[0];
-    private List<String> slices = new ArrayList<String>();
-    private Path rockcraftYaml = null;
     private boolean createService = true;
 
     /**
@@ -61,24 +48,6 @@ public class RockcraftOptions {
     }
 
     /**
-     * Get the Ubuntu OpenJDK package used to build the runtime image
-     *
-     * @return package name
-     */
-    public String getBuildPackage() {
-        return buildPackage;
-    }
-
-    /**
-     * Set the OpenJDK package used to build the runtime image
-     *
-     * @param buildPackage - Ubuntu package name
-     */
-    public void setBuildPackage(String buildPackage) {
-        this.buildPackage = buildPackage;
-    }
-
-    /**
      * Gets a flag whether to use jlink plugin (early access option).
      * Default - false.
      *
@@ -95,80 +64,6 @@ public class RockcraftOptions {
      */
     public void setJlink(boolean jlink) {
         this.jlink = jlink;
-    }
-
-    /**
-     * Gets <i>chisel-releases</i> branch
-     *
-     * @return <i>chisel-releases</i> branch
-     */
-    public String getBranch() {
-        return branch;
-    }
-
-    /**
-     * Sets <i>chisel-releases</i> branch
-     *
-     * @param branch - git branch
-     */
-    public void setBranch(String branch) {
-        this.branch = branch;
-    }
-
-    /**
-     * Gets the summary comment for the ROCK
-     *
-     * @return summary comment
-     */
-    public String getSummary() {
-        return summary;
-    }
-
-    /**
-     * Sets the summary comment for the ROCK
-     *
-     * @param summary - summary comment
-     */
-    public void setSummary(String summary) {
-        this.summary = summary;
-    }
-
-    /**
-     * Gets a description file for the ROCK
-     *
-     * @return path to the description
-     */
-    public Path getDescription() {
-        return description;
-    }
-
-    /**
-     * Sets the path to the description file
-     *
-     * @param description - description file
-     */
-    public void setDescription(String description) {
-        if (description != null) {
-            this.description = Paths.get(description);
-        }
-    }
-
-    /**
-     * Gets the list of the supported architectures
-     *
-     * @return supported architectures
-     */
-    public RockArchitecture[] getArchitectures() {
-        return architectures;
-    }
-
-    /**
-     * Sets the list of the supported architectures
-     *
-     * @param architectures - supported architectures
-     */
-    public void setArchitectures(RockArchitecture[] architectures) {
-        this.architectures = architectures;
     }
 
     /**
@@ -189,62 +84,6 @@ public class RockcraftOptions {
         this.command = command;
     }
 
-    /**
-     * Get chisel slices to install
-     *
-     * @return list of the slice names
-     */
-    public List<String> getSlices() {
-        return slices;
-    }
-
-    /**
-     * Overrides chisel slices to install
-     *
-     * @param slices - list of chisel slices
-     */
-    public void setSlices(List<String> slices) {
-        this.slices = slices;
-    }
-
-    /**
-     * Get Git repository URL of the <i>chisel-releases</i>
-     *
-     * @return Git repository URL
-     */
-    public String getSource() {
-        return source;
-    }
-
-    /**
-     * Override <i>chisel-releases</i> repository URL
-     *
-     * @param source - Git repository URL
-     */
-    public void setSource(String source) {
-        this.source = source;
-    }
-
-
-    /**
-     * Get path to the optional rockcraft.yaml
-     *
-     * @return path to rockcraft yaml
-     */
-    public Path getRockcraftYaml() {
-        return rockcraftYaml;
-    }
-
-    /**
-     * Sets the path to rockcraft.yaml file
-     *
-     * @param rockcraftYaml - rockcraft yaml file
-     */
-    public void setRockcraftYaml(String rockcraftYaml) {
-        if (rockcraftYaml != null) {
-            this.rockcraftYaml = Paths.get(rockcraftYaml);
-        }
-    }
 
     /**
      * Get whether to create service section


### PR DESCRIPTION
In order to start development of build/test rock generator, extract common code:
 - Move architecture enums to the top level 
 - Introduce generator enum and use it in settings
 - introduce abstract base class for RockCrafter
 - extract common options for rock generations 


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
