### PR TITLE
feat: add dependency task

### DIFF
--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/DependencyExportTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/DependencyExportTask.java
@@ -36,6 +36,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.StringTokenizer;
 
 /**
  * DependencyExportTask writes the project build dependencies to the output
@@ -110,8 +111,17 @@ public abstract class DependencyExportTask extends DefaultTask {
         File f = resolvedArtifact.getFile();
         // gradle cache stores artifacts in <artifact>/<sha1>/<file> directory structure
         File componentLocation = f.getParentFile().getParentFile();
-        String relativePath = resolvedArtifact.getId().getComponentIdentifier().getDisplayName().replace(':', File.separatorChar);
-        Path outputLocation = outputLocationRoot.resolve(relativePath);
+        StringTokenizer tk = new StringTokenizer(resolvedArtifact.getId().getComponentIdentifier().getDisplayName(), ":");
+        StringBuilder relativePath = new StringBuilder();
+        if (tk.hasMoreTokens()) {
+            relativePath.append(tk.nextToken().replace('.', File.separatorChar));
+        }
+        while (tk.hasMoreTokens()) {
+            relativePath.append(File.separatorChar);
+            relativePath.append(tk.nextToken());
+        }
+
+        Path outputLocation = outputLocationRoot.resolve(relativePath.toString());
         File[] components = componentLocation.listFiles();
         if (components == null) {
             return;

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/DependencyExportTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/DependencyExportTask.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.gradle;
+
+import com.canonical.rockcraft.builder.DependencyOptions;
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.ArtifactCollection;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+public abstract class DependencyExportTask extends DefaultTask {
+    private final Logger logger = Logging.getLogger(DependencyExportTask.class);
+    private final ArrayList<ModuleVersionIdentifier> workQueue = new ArrayList<>();
+    private final DependencyOptions dependencyOptions;
+
+    @Inject
+    public DependencyExportTask(DependencyOptions options) {
+        dependencyOptions = options;
+    }
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
+
+    @TaskAction
+    public void export() throws IOException {
+        for (String configName : dependencyOptions.getConfigurations()) {
+            Configuration config = this.getProject().getConfigurations().findByName(configName);
+            if (config == null) {
+                throw new IllegalArgumentException(String.format("Configuration %s not found.", configName));
+            }
+            ArtifactCollection artifacts = config.getIncoming().getArtifacts();
+            copyArtifacts(artifacts);
+        }
+        // export build script dependencies
+        this.getProject().getBuildscript().getConfigurations().all(new Action<Configuration>() {
+            @Override
+            public void execute(Configuration files) {
+                for (Dependency dep : files.getAllDependencies()) {
+                    ArtifactCollection artifacts = getProject()
+                            .getBuildscript()
+                            .getConfigurations()
+                            .detachedConfiguration(dep)
+                            .getIncoming()
+                            .getArtifacts();
+                    try {
+                        copyArtifacts(artifacts);
+                    }
+                    catch (IOException ex) {
+                        throw new RuntimeException(ex);
+                    }
+
+                }
+            }
+        });
+    }
+
+    private void copyArtifacts(ArtifactCollection artifacts) throws IOException {
+        Path outputLocationRoot = getOutputDirectory().getAsFile().get().toPath();
+        for (ResolvedArtifactResult result : artifacts.getArtifacts()) {
+            copyFromGradleCache(result, outputLocationRoot);
+        }
+    }
+
+    private void copyFromGradleCache(ResolvedArtifactResult resolvedArtifact, Path outputLocationRoot ) throws IOException {
+        File f = resolvedArtifact.getFile();
+        // gradle cache stores artifacts in <artifact>/<sha1>/<file> directory structure
+        File componentLocation = f.getParentFile().getParentFile();
+        String relativePath = resolvedArtifact.getId().getComponentIdentifier().getDisplayName().replace(':', File.separatorChar);
+        Path outputLocation = outputLocationRoot.resolve(relativePath);
+        for (File component : componentLocation.listFiles()) {
+            Optional<File> file = Arrays.stream(component.listFiles()).findFirst();
+            if (file.isEmpty())
+                continue;
+            outputLocation.toFile().mkdirs();
+            Path output = outputLocation.resolve(file.get().getName());
+            Files.copy(file.get().toPath(), output, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+            Path outputSha1 = Path.of(output.toFile().getAbsolutePath() + ".sha1");
+            String paddedSha1 = String.format("%40s", component.getName()).replace(' ', '0');
+            Files.writeString(outputSha1, paddedSha1);
+            logger.debug(String.format("Written %s and corresponding sha1", output));
+        }
+    }
+}

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/DependencyExportTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/DependencyExportTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2025 Canonical Ltd.
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -37,19 +37,35 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * DependencyExportTask writes the project build dependencies to the output
+ * directory.
+ */
 public abstract class DependencyExportTask extends DefaultTask {
     private final Logger logger = Logging.getLogger(DependencyExportTask.class);
     private final ArrayList<ModuleVersionIdentifier> workQueue = new ArrayList<>();
     private final DependencyOptions dependencyOptions;
 
+    /**
+     * Constructs DependencyExportTask
+     * @param options - dependency export options
+     */
     @Inject
     public DependencyExportTask(DependencyOptions options) {
         dependencyOptions = options;
     }
 
+    /**
+     * Output directory for the dependency export
+     * @return DirectoryProperty
+     */
     @OutputDirectory
     public abstract DirectoryProperty getOutputDirectory();
 
+    /**
+     * Task action to write dependencies
+     * @throws IOException - failed to write project dependencies
+     */
     @TaskAction
     public void export() throws IOException {
         for (String configName : dependencyOptions.getConfigurations()) {
@@ -96,10 +112,19 @@ public abstract class DependencyExportTask extends DefaultTask {
         File componentLocation = f.getParentFile().getParentFile();
         String relativePath = resolvedArtifact.getId().getComponentIdentifier().getDisplayName().replace(':', File.separatorChar);
         Path outputLocation = outputLocationRoot.resolve(relativePath);
-        for (File component : componentLocation.listFiles()) {
-            Optional<File> file = Arrays.stream(component.listFiles()).findFirst();
-            if (file.isEmpty())
+        File[] components = componentLocation.listFiles();
+        if (components == null) {
+            return;
+        }
+        for (File component : components) {
+            File[] files = component.listFiles();
+            if (files == null) {
                 continue;
+            }
+            Optional<File> file = Arrays.stream(files).findFirst();
+            if (file.isEmpty()) {
+                continue;
+            }
             outputLocation.toFile().mkdirs();
             Path output = outputLocation.resolve(file.get().getName());
             Files.copy(file.get().toPath(), output, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.canonical.rockcraft.gradle;
 
 import org.gradle.testkit.runner.BuildResult;

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
@@ -42,9 +42,9 @@ public class DependencyExportTest extends BaseRockcraftTest {
         writeString(getBuildFile(), getResource("dependencies-build.in"));
         BuildResult result = runBuild("dependencies-export", "--stacktrace");
         assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
-        Path springBoot = projectDir.toPath().resolve("build/dependencies/org.springframework.boot/spring-boot/3.0.6/spring-boot-3.0.6.jar");
+        Path springBoot = projectDir.toPath().resolve("build/dependencies/org/springframework/boot/spring-boot/3.0.6/spring-boot-3.0.6.jar");
         assertTrue(springBoot.toFile().exists(), "Spring Boot Jar is downloaded");
-        Path springBootSha1 = projectDir.toPath().resolve("build/dependencies/org.springframework.boot/spring-boot/3.0.6/spring-boot-3.0.6.jar.sha1");
+        Path springBootSha1 = projectDir.toPath().resolve("build/dependencies/org/springframework/boot/spring-boot/3.0.6/spring-boot-3.0.6.jar.sha1");
         String sha1 = Files.readString(springBootSha1);
         assertEquals("095ac2c7aa28fcdef587b2c4f554016f8b9af624", sha1);
     }

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
@@ -1,0 +1,43 @@
+package com.canonical.rockcraft.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DependencyExportTest extends BaseRockcraftTest {
+
+    @BeforeEach
+    protected void setUp() throws IOException {
+        super.setUp();
+    }
+
+    @Test
+    public void testDefaultExport() {
+        // The project should export dependencies without any dependant libraries
+        BuildResult result = runBuild("dependencies-export", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+        Path dependencies = projectDir.toPath().resolve("build/dependencies/");
+        assertEquals(0, dependencies.toFile().list().length);
+    }
+
+    @Test
+    public void testExport() throws IOException {
+        // export dependencies with implementation and testImplementation dependencies
+        writeString(getBuildFile(), getResource("dependencies-build.in"));
+        BuildResult result = runBuild("dependencies-export", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+        Path springBoot = projectDir.toPath().resolve("build/dependencies/org.springframework.boot/spring-boot/3.0.6/spring-boot-3.0.6.jar");
+        assertTrue(springBoot.toFile().exists(), "Spring Boot Jar is downloaded");
+        Path springBootSha1 = projectDir.toPath().resolve("build/dependencies/org.springframework.boot/spring-boot/3.0.6/spring-boot-3.0.6.jar.sha1");
+        String sha1 = Files.readString(springBootSha1);
+        assertEquals("095ac2c7aa28fcdef587b2c4f554016f8b9af624", sha1);
+    }
+}

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
@@ -27,11 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DependencyExportTest extends BaseRockcraftTest {
 
-    @BeforeEach
-    protected void setUp() throws IOException {
-        super.setUp();
-    }
-
     @Test
     public void testDefaultExport() {
         // The project should export dependencies without any dependant libraries

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/dependencies-build.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/dependencies-build.in
@@ -1,0 +1,21 @@
+plugins {
+    id('application')
+    id('io.github.rockcrafters.rockcraft')
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation platform('org.springframework.boot:spring-boot-dependencies:3.0.6')
+    implementation 'org.springframework.boot:spring-boot-starter:3.0.6'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.6'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'Test'
+    }
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/DependencyOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/DependencyOptions.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2024 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+/**
+ * Dependency export options:
+ *  - List of configurations
+ */
+public class DependencyOptions  {
+
+    public String[] getConfigurations() {
+        return configurations;
+    }
+
+    public void setConfigurations(String[] configurations) {
+        this.configurations = configurations;
+    }
+
+    private String[] configurations;
+}


### PR DESCRIPTION
This PR adds `dependency-export` task that stores project dependencies needed to compile and test the application under `buildDir/dependencies` as an offline maven repository.


- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
