### PR TITLE
feat: implement build rock support for gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ target architectures and the startup service command line.
 
 ### 3. Export Dependencies
 
-The plugin provides `dependencies-export` task that stores project dependencies into `build/build-rock/dependences`. 
+The plugin provides `dependencies-export` task that stores project dependencies into `build/build-rock/dependences`.
 This is equivalent to [Maven dependency plugin](https://maven.apache.org/plugins/maven-dependency-plugin/)
 [go-offline](https://maven.apache.org/plugins/maven-dependency-plugin/go-offline-mojo.html) goal.
 By default, the task exports all resolvable configurations of the project and buildscript.
@@ -149,6 +149,39 @@ The `dependenciesExport` configuration allows to customize the list of exported 
     dependenciesExport {
         buildScript = true
         configurations("runtimeClasspath", "testRuntimeClasspath")
+    }
+
+### 4. Create build container
+
+The plugin provides `create-build-rock` and `build-build-rock` tasks
+that creates a chiselled build container. It contains a local maven
+repository with all the project dependencies, chiselled openjdk
+and Gradle installation.
+
+**Groovy**
+
+    buildRockcraft {
+        buildPackage = "openjdk-21-jdk"
+        summary = "A ROCK summary"
+        description = "README.md"
+        source = "http://github.com/myuser/chisel-releases"
+        branch = "my-chisel-release-branch"
+        slices("busybox_bins", "fontconfig_config")
+        architectures("amd64", "arm64")
+        rockcraftYaml =  "rockcraft.yaml"
+    }
+
+**Kotlin**
+
+    buildRockcraft {
+        buildPackage = "openjdk-21-jdk"
+        summary = "A ROCK summary"
+        description = "README.md"
+        source = "http://github.com/myuser/chisel-releases"
+        branch = "my-chisel-release-branch"
+        slices("busybox_bins", "fontconfig_config")
+        architectures("amd64", "arm64")
+        rockcraftYaml =  "rockcraft.yaml"
     }
 
 ## Examples

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/BuildBuildRockcraftTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/BuildBuildRockcraftTask.java
@@ -26,14 +26,14 @@ import java.io.IOException;
  * Gradle task to pack build/test rock
  */
 public class BuildBuildRockcraftTask extends DefaultTask {
-    private final CommonRockcraftOptions options;
+    private final BuildRockcraftOptions options;
 
     /**
      * Construct new BuildBuildRockcraftTask
      * @param options - rockcraft project options
      */
     @Inject
-    public BuildBuildRockcraftTask(CommonRockcraftOptions options) {
+    public BuildBuildRockcraftTask(BuildRockcraftOptions options) {
         this.options = options;
     }
 

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/BuildBuildRockcraftTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/BuildBuildRockcraftTask.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.gradle;
+
+import com.canonical.rockcraft.builder.CommonRockcraftOptions;
+import com.canonical.rockcraft.builder.RockBuilder;
+import com.canonical.rockcraft.builder.RockProjectSettings;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+/**
+ * Gradle task to pack build/test rock
+ */
+public class BuildBuildRockcraftTask extends DefaultTask {
+    private final CommonRockcraftOptions options;
+
+    /**
+     * Construct new BuildBuildRockcraftTask
+     * @param options - rockcraft project options
+     */
+    @Inject
+    public BuildBuildRockcraftTask(CommonRockcraftOptions options) {
+        this.options = options;
+    }
+
+    /**
+     * Pack the build rock
+     * @throws InterruptedException - rockcraft process was interrupted
+     * @throws IOException - rockcraft process failed to pack the rock
+     */
+    @TaskAction
+    public void buildBuildRock() throws InterruptedException, IOException {
+        RockProjectSettings settings = RockSettingsFactory.createBuildRockProjectSettings(getProject());
+        RockBuilder.buildRock(settings, options);
+    }
+}

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/BuildBuildRockcraftTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/BuildBuildRockcraftTask.java
@@ -13,7 +13,7 @@
  */
 package com.canonical.rockcraft.gradle;
 
-import com.canonical.rockcraft.builder.CommonRockcraftOptions;
+import com.canonical.rockcraft.builder.BuildRockcraftOptions;
 import com.canonical.rockcraft.builder.RockBuilder;
 import com.canonical.rockcraft.builder.RockProjectSettings;
 import org.gradle.api.DefaultTask;

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/CreateBuildRockcraftTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/CreateBuildRockcraftTask.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.gradle;
+
+import com.canonical.rockcraft.builder.BuildRockCrafter;
+import com.canonical.rockcraft.builder.BuildRockcraftOptions;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * CreateBuildRockcraftTask writes rockcraft.yaml for the build rock.
+ */
+public abstract class CreateBuildRockcraftTask extends DefaultTask {
+
+    private final BuildRockcraftOptions options;
+
+    /**
+     * Construct CreateBuildRockcraftTask
+     * @param options - rockcraft project options
+     */
+    @Inject
+    public CreateBuildRockcraftTask(BuildRockcraftOptions options) {
+        super();
+        this.options = options;
+    }
+
+    /**
+     * Task action to write rockcraft.yaml for the build rock
+     * @throws IOException - failed to write rockcraft.yaml
+     */
+    @TaskAction
+    @SuppressWarnings("unchecked")
+    public void writeRockcraft() throws IOException {
+        HashSet<File> artifacts = new HashSet<>();
+        Set<Object> dependsOn = getDependsOn();
+        for (Object entry : dependsOn) {
+            HashSet<Task> tasks = (HashSet<Task>) entry;
+            for (Task task : tasks) {
+                artifacts.addAll(task.getOutputs().getFiles().getFiles());
+            }
+        }
+        BuildRockCrafter crafter = new BuildRockCrafter(RockSettingsFactory.createBuildRockProjectSettings(getProject()),
+                options, new ArrayList<>(artifacts));
+        crafter.writeRockcraft();
+    }
+}

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
@@ -1,5 +1,6 @@
 package com.canonical.rockcraft.gradle;
 
+import com.canonical.rockcraft.builder.IRockcraftNames;
 import org.gradle.api.Project;
 
 import com.canonical.rockcraft.builder.Generator;
@@ -22,10 +23,26 @@ public class RockSettingsFactory {
      * @return RockProjectSettings
      */
     public static final RockProjectSettings createRockProjectSettings(Project project) {
-        return new RockProjectSettings(Generator.gradle, project.getName(),
-            String.valueOf(project.getVersion()), project.getProjectDir().toPath(),
-            project.getLayout().getBuildDirectory().getAsFile().get().toPath(),
+
+        return new RockProjectSettings(Generator.gradle, project.getGradle().getGradleVersion(),
+                project.getName(), String.valueOf(project.getVersion()),
+                project.getProjectDir().toPath(), project.getLayout().getBuildDirectory().getAsFile().get().toPath(),
                 !project.getTasksByName(ITaskNames.JLINK, false).isEmpty() ||
                         !project.getTasksByName(ITaskNames.RUNTIME, false).isEmpty());
     }
+
+    /**
+     * Creates RockProjectSettings from Gradle project for the build rock
+     *
+     * @param project - gradle project
+     * @return RockProjectSettings
+     */
+    public static final RockProjectSettings createBuildRockProjectSettings(Project project) {
+        return new RockProjectSettings(Generator.gradle, project.getGradle().getGradleVersion(),
+                project.getName(), String.valueOf(project.getVersion()),
+                project.getProjectDir().toPath(), project.getLayout().getBuildDirectory().getAsFile().get().toPath().resolve(IRockcraftNames.BUILD_ROCK_OUTPUT),
+                !project.getTasksByName(ITaskNames.JLINK, false).isEmpty() ||
+                        !project.getTasksByName(ITaskNames.RUNTIME, false).isEmpty());
+    }
+
 }

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockSettingsFactory.java
@@ -3,7 +3,7 @@ package com.canonical.rockcraft.gradle;
 import com.canonical.rockcraft.builder.IRockcraftNames;
 import org.gradle.api.Project;
 
-import com.canonical.rockcraft.builder.Generator;
+import com.canonical.rockcraft.builder.BuildSystem;
 import com.canonical.rockcraft.builder.RockProjectSettings;
 
 /**
@@ -24,7 +24,7 @@ public class RockSettingsFactory {
      */
     public static final RockProjectSettings createRockProjectSettings(Project project) {
 
-        return new RockProjectSettings(Generator.gradle, project.getGradle().getGradleVersion(),
+        return new RockProjectSettings(BuildSystem.gradle, project.getGradle().getGradleVersion(),
                 project.getName(), String.valueOf(project.getVersion()),
                 project.getProjectDir().toPath(), project.getLayout().getBuildDirectory().getAsFile().get().toPath(),
                 !project.getTasksByName(ITaskNames.JLINK, false).isEmpty() ||
@@ -38,7 +38,7 @@ public class RockSettingsFactory {
      * @return RockProjectSettings
      */
     public static final RockProjectSettings createBuildRockProjectSettings(Project project) {
-        return new RockProjectSettings(Generator.gradle, project.getGradle().getGradleVersion(),
+        return new RockProjectSettings(BuildSystem.gradle, project.getGradle().getGradleVersion(),
                 project.getName(), String.valueOf(project.getVersion()),
                 project.getProjectDir().toPath(), project.getLayout().getBuildDirectory().getAsFile().get().toPath().resolve(IRockcraftNames.BUILD_ROCK_OUTPUT),
                 !project.getTasksByName(ITaskNames.JLINK, false).isEmpty() ||

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockcraftPlugin.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockcraftPlugin.java
@@ -13,6 +13,7 @@
  */
 package com.canonical.rockcraft.gradle;
 
+import com.canonical.rockcraft.builder.BuildRockcraftOptions;
 import com.canonical.rockcraft.builder.DependencyOptions;
 import com.canonical.rockcraft.builder.IRockcraftNames;
 import com.canonical.rockcraft.builder.RockBuilder;
@@ -74,15 +75,27 @@ public class RockcraftPlugin implements Plugin<Project> {
                     .set(output.toFile());
         });
 
-        TaskProvider<Task> checkTask = project.getTasks().register("checkRockcraft", s ->
+        BuildRockcraftOptions buildOptions = project.getExtensions().create("buildRockcraft", BuildRockcraftOptions .class);
+        project.getTasks()
+                .register("create-build-rock", CreateBuildRockcraftTask.class, buildOptions);
+        project.getTasks()
+                .getByName("create-build-rock")
+                .dependsOn(project.getTasksByName("dependencies-export", false));
+        project.getTasks()
+                .register("build-build-rock", BuildBuildRockcraftTask.class, buildOptions);
+        project.getTasks()
+                .getByName("build-build-rock")
+                .dependsOn(project.getTasksByName("create-build-rock", false));
+
+        TaskProvider<Task> checkTask = project.getTasks().register("checkRockcraft", s -> {
             s.doFirst(x -> {
                 try {
                     RockBuilder.checkRockcraft();
                 } catch (IOException | InterruptedException e) {
                     throw new UnsupportedOperationException(e.getMessage());
                 }
-            }
-        ));
+            });
+        });
 
         Set<Task> buildTasks = project.getTasksByName("build", false);
         if (buildTasks.isEmpty())

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.gradle;
+
+import com.canonical.rockcraft.builder.IRockcraftNames;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreateBuildRockTest extends BaseRockcraftTest {
+
+    @Test
+    public void testExport() throws IOException {
+        writeString(getBuildFile(), getResource("dependencies-build.in"));
+        BuildResult result = runBuild("build-build-rock", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+        // the task needs to run export dependencies
+        Path springBoot = projectDir.toPath().resolve("build/" + IRockcraftNames.BUILD_ROCK_OUTPUT + "/" + IRockcraftNames.DEPENDENCIES_ROCK_OUTPUT + "/org/springframework/boot/spring-boot/2.7.9/spring-boot-2.7.9.jar");
+        assertTrue(springBoot.toFile().exists(), "Spring Boot Jar is downloaded");
+        Path springBootSha1 = projectDir.toPath().resolve("build/" + IRockcraftNames.BUILD_ROCK_OUTPUT + "/" + IRockcraftNames.DEPENDENCIES_ROCK_OUTPUT + "/org/springframework/boot/spring-boot/2.7.9/spring-boot-2.7.9.jar.sha1");
+        String sha1 = new String(Files.readAllBytes(springBootSha1));
+        assertEquals("788d60e73e0f7bbbf11b30c3fb0a9cbaa073446b", sha1);
+        Path springBootPom = projectDir.toPath().resolve("build/" + IRockcraftNames.BUILD_ROCK_OUTPUT + "/" + IRockcraftNames.DEPENDENCIES_ROCK_OUTPUT + "/org/springframework/boot/spring-boot/2.7.9/spring-boot-2.7.9.pom");
+        assertTrue(springBootPom.toFile().exists(), "Spring Boot POM is downloaded");
+
+    }
+}

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
@@ -13,6 +13,7 @@
  */
 package com.canonical.rockcraft.gradle;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -73,6 +74,21 @@ public class CreateBuildRockTest extends BaseRockcraftTest {
             Map<String, Object> cachePart =(Map<String, Object>) parts.get("maven-cache");
             buildScript = (String)cachePart.get("override-build");
             assertTrue(buildScript.contains("${CRAFT_PART_INSTALL}/var/lib/pebble/default/.m2/repository/"));
+        }
+    }
+
+    @Test
+    public void testBuildrockcraftOptions() throws IOException {
+        writeString(getBuildFile(), getResource("build-rockcraft-options.in"));
+        File buildRock = new File(getProjectDir(), "build-rock");
+        buildRock.mkdirs();
+        writeString(new File(buildRock, "rockcraft.yaml"), "name: the-rock");
+        BuildResult result = runBuild("create-build-rock", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+        try (FileInputStream is = new FileInputStream(Paths.get(getProjectDir().getAbsolutePath(), "build", IRockcraftNames.BUILD_ROCK_OUTPUT, IRockcraftNames.ROCKCRAFT_YAML).toFile())) {
+            Yaml yaml = new Yaml();
+            Map<String, Object> parsed = yaml.load(is);
+            assertEquals("the-rock",parsed.get("name"));
         }
     }
 }

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
@@ -13,21 +13,28 @@
  */
 package com.canonical.rockcraft.gradle;
 
-import com.canonical.rockcraft.builder.IRockcraftNames;
-import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.TaskOutcome;
-import org.junit.jupiter.api.Test;
-
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import com.canonical.rockcraft.builder.IRockcraftNames;
 
 public class CreateBuildRockTest extends BaseRockcraftTest {
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testExport() throws IOException {
         writeString(getBuildFile(), getResource("dependencies-build.in"));
         BuildResult result = runBuild("build-build-rock", "--stacktrace");
@@ -41,5 +48,31 @@ public class CreateBuildRockTest extends BaseRockcraftTest {
         Path springBootPom = projectDir.toPath().resolve("build/" + IRockcraftNames.BUILD_ROCK_OUTPUT + "/" + IRockcraftNames.DEPENDENCIES_ROCK_OUTPUT + "/org/springframework/boot/spring-boot/2.7.9/spring-boot-2.7.9.pom");
         assertTrue(springBootPom.toFile().exists(), "Spring Boot POM is downloaded");
 
+        try (FileInputStream is = new FileInputStream(Paths.get(getProjectDir().getAbsolutePath(), "build", IRockcraftNames.BUILD_ROCK_OUTPUT, IRockcraftNames.ROCKCRAFT_YAML).toFile())) {
+            Yaml yaml = new Yaml();
+            Map<String, Object> parsed = yaml.load(is);
+            Object services = parsed.get("services");
+            assertNull(services, "build rock does not define services");
+
+            Map<String, Object> parts = (Map<String, Object>) parsed.get("parts");
+
+            Map<String, Object> buildToolPart =(Map<String, Object>) parts.get("build-tool");
+            List<String> buildPackages = (List<String>)buildToolPart.get("build-packages");
+            assertTrue(buildPackages.contains("unzip"));
+            assertTrue(buildPackages.contains("wget"));
+            String buildScript = (String)buildToolPart.get("override-build");
+            assertTrue(buildScript.contains("craftctl default"), "default script action present");
+
+            Map<String, Object> dependenciesPart =(Map<String, Object>) parts.get("dependencies");
+            buildPackages = (List<String>)dependenciesPart.get("build-packages");
+            assertTrue(buildPackages.contains("busybox"));
+            assertTrue(buildPackages.contains("openjdk-21-jdk-headless"));
+            buildScript = (String)dependenciesPart.get("override-build");
+            assertTrue(buildScript.contains("craftctl default"), "default script action present");
+
+            Map<String, Object> cachePart =(Map<String, Object>) parts.get("maven-cache");
+            buildScript = (String)cachePart.get("override-build");
+            assertTrue(buildScript.contains("${CRAFT_PART_INSTALL}/var/lib/pebble/default/.m2/repository/"));
+        }
     }
 }

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/build-rockcraft-options.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/build-rockcraft-options.in
@@ -1,0 +1,27 @@
+plugins {
+    id('application')
+    id('io.github.rockcrafters.rockcraft')
+    id("io.gitlab.plunts.plantuml") version "2.0.0"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation platform('org.springframework.boot:spring-boot-dependencies:2.7.9')
+    implementation 'org.springframework.boot:spring-boot-starter:2.7.9'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.9'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+buildRockcraft {
+    rockcraftYaml = "build-rock/rockcraft.yaml"
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'Test'
+    }
+}

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/AbstractRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/AbstractRockMojo.java
@@ -17,8 +17,10 @@ import com.canonical.rockcraft.builder.RockArchitecture;
 import com.canonical.rockcraft.builder.RockcraftOptions;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.rtinfo.RuntimeInformation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +38,9 @@ public abstract class AbstractRockMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Component
+    private RuntimeInformation runtimeInformation;
 
     @Parameter(property = "buildPackage")
     private String buildPackage = "openjdk-21-jdk";
@@ -73,7 +78,6 @@ public abstract class AbstractRockMojo extends AbstractMojo {
     @Parameter(property = "service")
     private boolean createService = true;
 
-
     private RockcraftOptions options = new RockcraftOptions();
 
     /**
@@ -93,6 +97,13 @@ public abstract class AbstractRockMojo extends AbstractMojo {
     protected MavenProject getProject() {
         return project;
     }
+
+    /**
+     * Returns runtime information for Maven
+     *
+     * @return runtime information
+     */
+    protected RuntimeInformation getRuntimeInformation() { return runtimeInformation; }
 
     /**
      * Executes mojo. Initializes RockcraftOptions using plugin

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/BuildRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/BuildRockMojo.java
@@ -37,7 +37,7 @@ public class BuildRockMojo extends AbstractRockMojo {
     public void execute() throws MojoExecutionException {
         super.execute();
         try {
-            RockBuilder.buildRock(RockSettingsFactory.createRockProjectSettings(getProject()), getOptions());
+            RockBuilder.buildRock(RockSettingsFactory.createRockProjectSettings(getRuntimeInformation(), getProject()), getOptions());
         } catch (InterruptedException | IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/CreateRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/CreateRockMojo.java
@@ -17,6 +17,7 @@ import com.canonical.rockcraft.builder.RockCrafter;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.rtinfo.RuntimeInformation;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class CreateRockMojo extends AbstractRockMojo {
         if (jars.isEmpty()) {
             throw new MojoExecutionException("No project artifacts found.");
         }
-        RockCrafter rockCrafter = new RockCrafter(RockSettingsFactory.createRockProjectSettings(getProject()), getOptions(), jars);
+        RockCrafter rockCrafter = new RockCrafter(RockSettingsFactory.createRockProjectSettings(getRuntimeInformation(), getProject()), getOptions(), jars);
         try {
             rockCrafter.writeRockcraft();
         } catch (IOException e) {

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/PushRockMojo.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/PushRockMojo.java
@@ -37,7 +37,7 @@ public class PushRockMojo extends AbstractRockMojo {
     public void execute() throws MojoExecutionException {
         super.execute();
         try {
-            RockBuilder.pushRock(RockSettingsFactory.createRockProjectSettings(getProject()), getOptions());
+            RockBuilder.pushRock(RockSettingsFactory.createRockProjectSettings(getRuntimeInformation(), getProject()), getOptions());
         } catch (InterruptedException | IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
@@ -16,7 +16,7 @@ package com.canonical.rockcraft.maven;
 import com.canonical.rockcraft.builder.Generator;
 import com.canonical.rockcraft.builder.RockProjectSettings;
 import org.apache.maven.project.MavenProject;
-
+import org.apache.maven.rtinfo.RuntimeInformation;
 /**
  * Creates RockProjectSettings from Maven project
  */
@@ -33,8 +33,8 @@ public class RockSettingsFactory {
      * @param project - Maven project
      * @return RockProjectSettings
      */
-    public static final RockProjectSettings createRockProjectSettings(MavenProject project) {
-        return new RockProjectSettings(Generator.maven, project.getName(),
+    public static final RockProjectSettings createRockProjectSettings(RuntimeInformation info, MavenProject project) {
+        return new RockProjectSettings(Generator.maven, info.getMavenVersion(), project.getName(),
                 project.getVersion(), project.getBasedir().getAbsoluteFile().toPath(),
                 project.getArtifact().getFile().getParentFile().toPath(),
                 false);

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
@@ -17,6 +17,7 @@ import com.canonical.rockcraft.builder.BuildSystem;
 import com.canonical.rockcraft.builder.RockProjectSettings;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.rtinfo.RuntimeInformation;
+
 /**
  * Creates RockProjectSettings from Maven project
  */

--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
@@ -13,7 +13,7 @@
  */
 package com.canonical.rockcraft.maven;
 
-import com.canonical.rockcraft.builder.Generator;
+import com.canonical.rockcraft.builder.BuildSystem;
 import com.canonical.rockcraft.builder.RockProjectSettings;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.rtinfo.RuntimeInformation;
@@ -34,7 +34,7 @@ public class RockSettingsFactory {
      * @return RockProjectSettings
      */
     public static final RockProjectSettings createRockProjectSettings(RuntimeInformation info, MavenProject project) {
-        return new RockProjectSettings(Generator.maven, info.getMavenVersion(), project.getName(),
+        return new RockProjectSettings(BuildSystem.maven, info.getMavenVersion(), project.getName(),
                 project.getVersion(), project.getBasedir().getAbsoluteFile().toPath(),
                 project.getArtifact().getFile().getParentFile().toPath(),
                 false);

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
@@ -60,6 +60,7 @@ public abstract class AbstractRockCrafter {
      * @throws IOException - the method fails to write rockcraft.yaml
      */
     public void writeRockcraft() throws IOException {
+        getSettings().getRockOutput().toFile().mkdirs();
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(getSettings().getRockOutput().resolve(IRockcraftNames.ROCKCRAFT_YAML).toFile()))) {
             String rockcraft = createRockcraft(getSettings().getRockOutput(), getArtifacts());
             writer.write(rockcraft);

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
@@ -74,6 +74,7 @@ public abstract class AbstractRockCrafter {
         rockcraft.put(IRockcraftNames.ROCKCRAFT_NAME, getSettings().getName());
         rockcraft.put(IRockcraftNames.ROCKCRAFT_VERSION, String.valueOf(getSettings().getVersion()));
         rockcraft.put("summary", getOptions().getSummary());
+        rockcraft.put( "run-user", "_daemon_");
         Path description = getOptions().getDescription();
         if (description != null) {
             File descriptionFile = getSettings().getProjectPath().resolve(description).toFile();

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -81,18 +81,18 @@ public class BuildRockCrafter extends AbstractRockCrafter {
     private Map<String, Object> createBuildTool(RockProjectSettings settings, BuildRockcraftOptions options) {
         Map<String,Object> part = new HashMap<>();
         part.put("plugin", "nil");
-        if (settings.getGeneratorName() == Generator.maven) {
+        if (settings.getBuildSystem() == BuildSystem.maven) {
             part.put("stage-packages", new String[] {"maven"});
         }
-        else if (settings.getGeneratorName() == Generator.gradle) {
+        else if (settings.getBuildSystem() == BuildSystem.gradle) {
             part.put("build-packages", new String[] {"unzip", "wget"});
             StringBuilder sb = new StringBuilder();
-            sb.append(String.format("wget https://services.gradle.org/distributions/gradle-%s-bin.zip\n", settings.getGeneratorVersion()));
-            sb.append(String.format("unzip -o -qq gradle-%s-bin.zip\n", settings.getGeneratorVersion()));
+            sb.append(String.format("wget https://services.gradle.org/distributions/gradle-%s-bin.zip\n", settings.getBuildSystemVersion()));
+            sb.append(String.format("unzip -o -qq gradle-%s-bin.zip\n", settings.getBuildSystemVersion()));
             sb.append("mkdir -p $CRAFT_PART_INSTALL/usr/share/gradle\n");
             sb.append("mkdir -p $CRAFT_PART_INSTALL/usr/bin\n");
             sb.append("rm -rf $CRAFT_PART_INSTALL/usr/share/gradle/*\n");
-            sb.append(String.format("mv gradle-%s/* $CRAFT_PART_INSTALL/usr/share/gradle/\n", settings.getGeneratorVersion()));
+            sb.append(String.format("mv gradle-%s/* $CRAFT_PART_INSTALL/usr/share/gradle/\n", settings.getBuildSystemVersion()));
             sb.append("cd $CRAFT_PART_INSTALL/ && ln -s --relative usr/share/gradle/bin/gradle usr/bin/");
             part.put("override-build", sb.toString());
         }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -127,7 +127,7 @@ public class BuildRockCrafter extends AbstractRockCrafter {
     private Map<String, Object> createDependenciesPart() {
         Map<String,Object> part = new HashMap<>();
         part.put("plugin", "nil");
-        part.put("build-packages", new String[] {"busybox", "default-jre-headless"});
+        part.put("build-packages", new String[] {"busybox", options.getBuildPackage()});
 
         List<String> slices = getOptions().getSlices();
         slices.add("busybox_bins");

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -24,11 +24,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Creates build rock rockcraft.yaml
+ */
 public class BuildRockCrafter extends AbstractRockCrafter {
+
+    /**
+     * Create build rock RockCrafter
+     * @param settings - project settings
+     * @param options - project options
+     * @param artifacts - list of artifact directories containing project dependencies
+     */
     public BuildRockCrafter(RockProjectSettings settings, BuildRockcraftOptions options, List<File> artifacts) {
         super(settings, options, artifacts);
     }
 
+    /**
+     * Create rockcraft.yaml file
+     *
+     * @param root - rockcraft.yaml's directory
+     * @param files - directories containing dependencies
+     * @return rockcraft.yaml string
+     * @throws IOException - failed to generate rockcraft.yaml
+     */
     @Override
     protected String createRockcraft(Path root, List<File> files) throws IOException {
         if (files.size() != 1){

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -13,16 +13,17 @@
  */
 package com.canonical.rockcraft.builder;
 
-import com.canonical.rockcraft.util.MapMerger;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import com.canonical.rockcraft.util.MapMerger;
 
 /**
  * Creates build rock rockcraft.yaml
@@ -93,7 +94,8 @@ public class BuildRockCrafter extends AbstractRockCrafter {
             sb.append("mkdir -p $CRAFT_PART_INSTALL/usr/bin\n");
             sb.append("rm -rf $CRAFT_PART_INSTALL/usr/share/gradle/*\n");
             sb.append(String.format("mv gradle-%s/* $CRAFT_PART_INSTALL/usr/share/gradle/\n", settings.getBuildSystemVersion()));
-            sb.append("cd $CRAFT_PART_INSTALL/ && ln -s --relative usr/share/gradle/bin/gradle usr/bin/");
+            sb.append("cd $CRAFT_PART_INSTALL/ && ln -s --relative usr/share/gradle/bin/gradle usr/bin/\n");
+            sb.append("craftctl default\n");
             part.put("override-build", sb.toString());
         }
         return part;

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+import com.canonical.rockcraft.util.MapMerger;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BuildRockCrafter extends AbstractRockCrafter {
+    public BuildRockCrafter(RockProjectSettings settings, BuildRockcraftOptions options, List<File> artifacts) {
+        super(settings, options, artifacts);
+    }
+
+    @Override
+    protected String createRockcraft(Path root, List<File> files) throws IOException {
+        if (files.size() != 1){
+            throw new UnsupportedOperationException("Build rock requires a single file input - a directory with a maven repository of dependencies");
+        }
+        BuildRockcraftOptions buildOptions = (BuildRockcraftOptions) getOptions();
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        Yaml yaml = new Yaml(dumperOptions);
+        Map<String, Object> rockcraft = MapMerger.merge(createCommonSection(), loadRockcraftSnippet(yaml));
+
+        StringBuilder yamlOutput = new StringBuilder();
+        yamlOutput.append(yaml.dump(rockcraft));
+        yamlOutput.append("\n");
+        rockcraft.clear();
+
+        rockcraft.put("parts", createParts(getSettings(), buildOptions, files));
+        yamlOutput.append(yaml.dump(rockcraft));
+        rockcraft.clear();
+
+        return yamlOutput.toString();
+    }
+
+    private Map<String, Object> createParts(RockProjectSettings settings, BuildRockcraftOptions options, List<File> files) {
+        Map<String,Object> parts = new HashMap<>();
+        parts.put("dependencies", createDependenciesPart());
+        parts.put("maven-cache", createMavenRepository(settings, options, files));
+        parts.put("build-tool", createBuildTool(settings, options));
+        return parts;
+    }
+
+    private Map<String, Object> createBuildTool(RockProjectSettings settings, BuildRockcraftOptions options) {
+        Map<String,Object> part = new HashMap<>();
+        part.put("plugin", "nil");
+        if (settings.getGeneratorName() == Generator.maven) {
+            part.put("stage-packages", new String[] {"maven"});
+        }
+        else if (settings.getGeneratorName() == Generator.gradle) {
+            part.put("build-packages", new String[] {"unzip", "wget"});
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("wget https://services.gradle.org/distributions/gradle-%s-bin.zip\n", settings.getGeneratorVersion()));
+            sb.append(String.format("unzip -o -qq gradle-%s-bin.zip\n", settings.getGeneratorVersion()));
+            sb.append("mkdir -p $CRAFT_PART_INSTALL/usr/share/gradle\n");
+            sb.append("mkdir -p $CRAFT_PART_INSTALL/usr/bin\n");
+            sb.append("rm -rf $CRAFT_PART_INSTALL/usr/share/gradle/*\n");
+            sb.append(String.format("mv gradle-%s/* $CRAFT_PART_INSTALL/usr/share/gradle/\n", settings.getGeneratorVersion()));
+            sb.append("cd $CRAFT_PART_INSTALL/ && ln -s --relative usr/share/gradle/bin/gradle usr/bin/");
+            part.put("override-build", sb.toString());
+        }
+        return part;
+    }
+
+    private Map<String, Object> createMavenRepository(RockProjectSettings settings, BuildRockcraftOptions options, List<File> files) {
+        Map<String,Object> part = new HashMap<>();
+        part.put("plugin", "nil");
+        String source = settings.getRockOutput().relativize(files.get(0).toPath()).toString();
+        part.put("source", source);
+        part.put("source-type", "local");
+        StringBuilder commands = new StringBuilder();
+        commands.append("mkdir -p ${CRAFT_PART_INSTALL}/var/lib/pebble/default/.m2/repository/\n");
+        commands.append("cp -r * ${CRAFT_PART_INSTALL}/var/lib/pebble/default/.m2/repository/\n");
+        commands.append("# workaround https://github.com/canonical/craft-parts/issues/507\n");
+        commands.append("chown -R 584792:584792  ${CRAFT_PART_INSTALL}/var/lib/pebble/default\n");
+        commands.append("craftctl default");
+        part.put("override-build", commands.toString());
+
+        HashMap<String, Object> permissions = new HashMap<>();
+        permissions.put("path", "/var/lib/pebble/default");
+        permissions.put("owner", 584792);
+        permissions.put("group", 584792);
+        permissions.put("mode", "755");
+        part.put("permissions", new HashMap[] { permissions });
+        return part;
+    }
+
+    private Map<String, Object> createDependenciesPart() {
+        Map<String,Object> part = new HashMap<>();
+        part.put("plugin", "nil");
+        part.put("build-packages", new String[] {"busybox", "default-jre-headless"});
+
+        List<String> slices = getOptions().getSlices();
+        slices.add("busybox_bins");
+        slices.add("base-files_base");
+        slices.add(options.getBuildPackage() + "_standard");
+        slices.add(options.getBuildPackage() + "_headers");
+        slices.add(options.getBuildPackage() + "_debug-headers");
+
+        if (getOptions().getSource() != null) {
+            part.put("source", getOptions().getSource());
+            part.put("source-type", "git");
+        }
+        if (getOptions().getBranch() != null) {
+            part.put("source-branch", getOptions().getBranch());
+        }
+
+        StringBuilder overrideCommands = new StringBuilder();
+        overrideCommands.append("chisel cut ");
+        if (getOptions().getSource() != null) {
+            overrideCommands.append("--release ./ ");
+        }
+        overrideCommands.append(" --root ${CRAFT_PART_INSTALL}/ \\\n");
+        for (String slice : slices) {
+            overrideCommands.append(" ");
+            overrideCommands.append(slice);
+            overrideCommands.append(" \\\n");
+        }
+        overrideCommands.append("\n");
+        overrideCommands.append("busybox --install -s ${CRAFT_PART_INSTALL}/usr/bin/\n");
+        overrideCommands.append("cd ${CRAFT_PART_INSTALL} && PATH=/usr/bin find . -type f -name java -exec ln -sf --relative {} ${CRAFT_PART_INSTALL}/usr/bin/ \\;\n");
+        overrideCommands.append("mkdir -p ${CRAFT_PART_INSTALL}/etc/ssl/certs/java/ &&  cp /etc/ssl/certs/java/cacerts ${CRAFT_PART_INSTALL}/etc/ssl/certs/java/cacerts");
+
+        overrideCommands.append("\ncraftctl default\n");
+        part.put("override-build", overrideCommands.toString());
+        return part;
+    }
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockcraftOptions.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+public class BuildRockcraftOptions extends CommonRockcraftOptions {
+    public BuildRockcraftOptions() {
+        super();
+        setBuildPackage("openjdk-21-jdk-headless");
+    }
+}

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildSystem.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildSystem.java
@@ -13,7 +13,10 @@
  */
 package com.canonical.rockcraft.builder;
 
-public enum Generator {
+/**
+ * Build system enumeration
+ */
+public enum BuildSystem {
     maven,
     gradle
 }

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockBuilder.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockBuilder.java
@@ -56,7 +56,7 @@ public class RockBuilder {
      * @throws InterruptedException - <i>rockcraft</i> process was aborted
      */
     @SuppressWarnings("unchecked")
-    public static void pushRock(RockProjectSettings settings, RockcraftOptions options) throws InterruptedException, IOException {
+    public static void pushRock(RockProjectSettings settings, CommonRockcraftOptions options) throws InterruptedException, IOException {
         Yaml yaml = new Yaml();
         Map<String, Object> rockcraft = (Map<String, Object>) yaml.load(new FileReader(settings.getRockOutput().resolve(IRockcraftNames.ROCKCRAFT_YAML).toFile()));
         String imageName = String.valueOf(rockcraft.get(IRockcraftNames.ROCKCRAFT_NAME));
@@ -75,7 +75,7 @@ public class RockBuilder {
      * @throws IOException          - IO error while writing <i>rockcraft.yaml</i>
      * @throws InterruptedException - <i>rockcraft</i> process was aborted
      */
-    public static void buildRock(RockProjectSettings settings, RockcraftOptions options) throws InterruptedException, IOException {
+    public static void buildRock(RockProjectSettings settings, CommonRockcraftOptions options) throws InterruptedException, IOException {
         ProcessBuilder pb = new ProcessBuilder("rockcraft", "pack")
                 .directory(settings.getRockOutput().toFile())
                 .inheritIO();

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -115,10 +115,10 @@ public class RockCrafter extends AbstractRockCrafter {
         HashMap<String, Object> parts = new HashMap<String, Object>();
         int id = 0;
         for (String image : images) {
-            parts.put(String.format("%s/rockcraft/dump%d",getSettings().getGeneratorName(), id), getImageDumpPart(image));
+            parts.put(String.format("%s/rockcraft/dump%d",getSettings().getBuildSystem(), id), getImageDumpPart(image));
             ++id;
         }
-        parts.put(String.format("%s/rockcraft/deps", getSettings().getGeneratorName()) , getDepsPart());
+        parts.put(String.format("%s/rockcraft/deps", getSettings().getBuildSystem()) , getDepsPart());
         return parts;
     }
 
@@ -188,14 +188,14 @@ public class RockCrafter extends AbstractRockCrafter {
         RockcraftOptions options = (RockcraftOptions) getOptions();
         IRuntimeProvider provider = options.getJlink() ? new JLinkRuntimePart(options) : new RawRuntimePart(options);
         HashMap<String, Object> parts = new HashMap<String, Object>();
-        parts.put(getSettings().getGeneratorName() + "/rockcraft/dump", getDumpPart(relativeJars));
+        parts.put(getSettings().getBuildSystem() + "/rockcraft/dump", getDumpPart(relativeJars));
         Map<java.lang.String,java.lang.Object> runtimePart = provider.getRuntimePart(files);
         runtimePart.put("after", new String[]{
-                getSettings().getGeneratorName() + "/rockcraft/dump",
-                getSettings().getGeneratorName() + "/rockcraft/deps"
+                getSettings().getBuildSystem() + "/rockcraft/dump",
+                getSettings().getBuildSystem() + "/rockcraft/deps"
         });
-        parts.put(getSettings().getGeneratorName() + "/rockcraft/runtime", runtimePart);
-        parts.put(getSettings().getGeneratorName() + "/rockcraft/deps", getDepsPart());
+        parts.put(getSettings().getBuildSystem() + "/rockcraft/runtime", runtimePart);
+        parts.put(getSettings().getBuildSystem() + "/rockcraft/deps", getDepsPart());
         return parts;
     }
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
@@ -9,25 +9,25 @@ public class RockProjectSettings {
     private final String name;
     private final String version;
     private final Path projectPath;
-    private final Generator generatorName;
-    private final String generatorVersion;
+    private final BuildSystem buildSystem;
+    private final String buildSystemVersion;
     private final Path rockOutput;
     private final boolean beryxJlink;
 
     /**
      * Constructs the rock project settings
      *
-     * @param generatorName name of the generator
-     * @param generatorVersion version of the generator
+     * @param buildSystem name of the build system
+     * @param buildSystemVersion version of the build system
      * @param name          rockcraft project name
      * @param version       rockcraft project version
      * @param projectPath   path to the rockcraft project
      * @param rockOutput    path to where to generate rockcraft.yaml
      * @param beryxJlink    whether to copy Beryx jlink image to the rock
      */
-    public RockProjectSettings(Generator generatorName, String generatorVersion, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
-        this.generatorName = generatorName;
-        this.generatorVersion = generatorVersion;
+    public RockProjectSettings(BuildSystem buildSystem, String buildSystemVersion, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
+        this.buildSystem = buildSystem;
+        this.buildSystemVersion = buildSystemVersion;
         this.name = name;
         this.version = version;
         this.projectPath = projectPath;
@@ -36,21 +36,21 @@ public class RockProjectSettings {
     }
 
     /**
-     * Get the generator name
+     * Get the build system
      *
-     * @return generator name
+     * @return build system
      */
-    public Generator getGeneratorName() {
-        return generatorName;
+    public BuildSystem getBuildSystem() {
+        return buildSystem;
     }
 
     /**
-     * Get the generator version
+     * Get the build system version
      *
-     * @return generator version
+     * @return build system version
      */
-    public String getGeneratorVersion() {
-        return generatorVersion;
+    public String getBuildSystemVersion() {
+        return buildSystemVersion;
     }
 
     /**

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockProjectSettings.java
@@ -10,6 +10,7 @@ public class RockProjectSettings {
     private final String version;
     private final Path projectPath;
     private final Generator generatorName;
+    private final String generatorVersion;
     private final Path rockOutput;
     private final boolean beryxJlink;
 
@@ -17,14 +18,16 @@ public class RockProjectSettings {
      * Constructs the rock project settings
      *
      * @param generatorName name of the generator
+     * @param generatorVersion version of the generator
      * @param name          rockcraft project name
      * @param version       rockcraft project version
      * @param projectPath   path to the rockcraft project
      * @param rockOutput    path to where to generate rockcraft.yaml
      * @param beryxJlink    whether to copy Beryx jlink image to the rock
      */
-    public RockProjectSettings(Generator generatorName, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
+    public RockProjectSettings(Generator generatorName, String generatorVersion, String name, String version, Path projectPath, Path rockOutput, boolean beryxJlink) {
         this.generatorName = generatorName;
+        this.generatorVersion = generatorVersion;
         this.name = name;
         this.version = version;
         this.projectPath = projectPath;
@@ -39,6 +42,15 @@ public class RockProjectSettings {
      */
     public Generator getGeneratorName() {
         return generatorName;
+    }
+
+    /**
+     * Get the generator version
+     *
+     * @return generator version
+     */
+    public String getGeneratorVersion() {
+        return generatorVersion;
     }
 
     /**

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
@@ -34,7 +34,7 @@ public class BuildRockCrafterTest {
 
     @Test
     public void testGenerateRock() throws IOException, InterruptedException {
-        RockProjectSettings settings = new RockProjectSettings(Generator.gradle,
+        RockProjectSettings settings = new RockProjectSettings(BuildSystem.gradle,
                 "8.12",
                 "project-name",
                 "project-version",

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
@@ -33,7 +33,7 @@ public class BuildRockCrafterTest {
     private File tempDir;
 
     @Test
-    public void testGenerateRock() throws IOException, InterruptedException {
+    public void testGenerateRock() throws IOException {
         RockProjectSettings settings = new RockProjectSettings(BuildSystem.gradle,
                 "8.12",
                 "project-name",

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.yaml.snakeyaml.Yaml;
+
+public class BuildRockCrafterTest {
+
+    @TempDir
+    private File tempDir;
+
+    @Test
+    public void testGenerateRock() throws IOException, InterruptedException {
+        RockProjectSettings settings = new RockProjectSettings(Generator.gradle,
+                "8.12",
+                "project-name",
+                "project-version",
+                tempDir.toPath(),
+                tempDir.toPath(),
+                false);
+        BuildRockcraftOptions options = new BuildRockcraftOptions();
+        options.setArchitectures(new RockArchitecture[]{ RockArchitecture.amd64 });
+
+        File output = tempDir.toPath().resolve("output").toFile();
+        output.mkdirs();
+        List<File> artifacts = new ArrayList<>();
+        artifacts.add(output);
+        BuildRockCrafter rockCrafter = new BuildRockCrafter(settings, options, artifacts);
+        rockCrafter.writeRockcraft();
+
+        Yaml yaml = new Yaml();
+        try (Reader r = new InputStreamReader(new FileInputStream(new File(tempDir, "rockcraft.yaml")))){
+            Map<String, Object> result = yaml.load(r);
+            Map<String, Object> parts = (Map<String, Object>) result.get("parts");
+            assertTrue(parts.containsKey("dependencies"));
+            assertTrue(parts.containsKey("maven-cache"));
+            assertTrue(parts.containsKey("build-tool"));
+        }
+
+        assertTrue(true, "The build should succeed");
+    }
+}


### PR DESCRIPTION
- chores: renamed Generator -> BuildSystem
- feat: build rock support. 
  - this adds two new tasks `create-build-rock` that exports dependencies and creates `build/build-rock/rockcraft.yaml` and `build-build-rock` that writes an oci container
  

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
