### PR TITLE
feat: add gradle init script to configure maven local repository

### DIFF
--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle.sh
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+WORKDIR=${1:-`pwd`}
+if [ $# -gt 0 ]; then
+    shift
+fi
+if [ $# -eq 0 ]; then
+    TASK=build -x checkRockcraft
+else
+    TASK=$@
+fi
+(cd ${WORKDIR} && gradle $TASK)

--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-maven.sh
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-maven.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+WORKDIR=${1:-`pwd`}
+if [ $# -gt 0 ]; then
+  shift
+fi
+if [ $# -eq 0 ]; then
+  GOAL=package
+else
+  GOAL=$@
+fi
+(cd $WORKDIR && mvn $GOAL)

--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/local-build.gradle
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/local-build.gradle
@@ -1,0 +1,15 @@
+apply plugin: AddLocalMaven
+class AddLocalMaven implements Plugin<Gradle> {
+    void apply(Gradle gradle) {
+        gradle.beforeSettings { settings ->
+            settings.pluginManagement.repositories {
+                mavenLocal()
+            }
+        }
+        gradle.allprojects {
+            project.repositories {
+                mavenLocal()
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Gradle build might not have maven local configured for the build rock, add init script to configure mavenLocal(). 
- Add 'build' script that can be used as a generic command in build rock: `build <directory-in-container> [ tasks/goals] `.



- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
