### PR TITLE
fix: add build- prefix to the build rock

### DIFF
--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
@@ -52,6 +52,8 @@ public class CreateBuildRockTest extends BaseRockcraftTest {
         try (FileInputStream is = new FileInputStream(Paths.get(getProjectDir().getAbsolutePath(), "build", IRockcraftNames.BUILD_ROCK_OUTPUT, IRockcraftNames.ROCKCRAFT_YAML).toFile())) {
             Yaml yaml = new Yaml();
             Map<String, Object> parsed = yaml.load(is);
+            String name = (String) parsed.get("name");
+            assertEquals("build-" + projectDir.getName(), name);
             Object services = parsed.get("services");
             assertNull(services, "build rock does not define services");
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -63,8 +63,11 @@ public class BuildRockCrafter extends AbstractRockCrafter {
         DumperOptions dumperOptions = new DumperOptions();
         dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         Yaml yaml = new Yaml(dumperOptions);
-        Map<String, Object> rockcraft = MapMerger.merge(createCommonSection(), loadRockcraftSnippet(yaml));
+        Map<String, Object> commonSection = createCommonSection();
+        String name = (String)commonSection.get("name");
+        commonSection.put("name", "build-" + name);
 
+        Map<String, Object> rockcraft = MapMerger.merge(commonSection, loadRockcraftSnippet(yaml));
         StringBuilder yamlOutput = new StringBuilder();
         yamlOutput.append(yaml.dump(rockcraft));
         yamlOutput.append("\n");


### PR DESCRIPTION
The names of runtime rock and the build rock were the same, so the push task was overwriting the image.

I have added `build-` prefix to the build rock name. 

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
