### PR TITLE
fix: set environment variables.

### DIFF
--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle.sh
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle.sh
@@ -8,4 +8,6 @@ if [ $# -eq 0 ]; then
 else
     TASK=$@
 fi
+export HOME=/var/lib/pebble/default
+export GRADLE_USER_HOME=${GRADLE_USER_HOME:-${WORKDIR}/.gradle}
 (cd ${WORKDIR} && gradle $TASK)

--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-maven.sh
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-maven.sh
@@ -8,4 +8,5 @@ if [ $# -eq 0 ]; then
 else
   GOAL=$@
 fi
+export HOME=/var/lib/pebble/default
 (cd $WORKDIR && mvn $GOAL)


### PR DESCRIPTION
This PR sets environment variables in `build` script, so that the user could use it using the chiselled build container.

This fixes the following issue:
```
docker run -v `pwd`:`pwd` --user $(id -u):$(id -g) --env PEBBLE=/tmp build-demo exec build `pwd` --no-daemon
```
Resulted in
```
FAILURE: Build failed with an exception.

...

* What went wrong:
Plugin [id: 'io.github.rockcrafters.rockcraft', version: '1.1.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Included Builds (No included builds contain this plugin)
- Plugin Repositories (could not resolve plugin artifact 'io.github.rockcrafters.rockcraft:io.github.rockcrafters.rockcraft.gradle.plugin:1.1.0')
  Searched in the following repositories:
    Gradle Central Plugin Repository
    MavenLocal(file:/.m2/repository)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 2s
```

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
