### PR TITLE
chore: enable jlink plugin

### DIFF
--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/RockcraftPluginTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/RockcraftPluginTest.java
@@ -62,7 +62,7 @@ class RockcraftPluginTest extends BaseRockcraftTest {
             Map<String, Object> dumpPart = (Map<String, Object>) parts.get("gradle/rockcraft/dump");
             assertTrue(dumpPart.containsKey("override-build"));
             Map<String, Object> runtimePart = (Map<String, Object>) parts.get("gradle/rockcraft/runtime");
-            assertTrue(runtimePart.containsKey("override-build"));
+            assertEquals("jlink", runtimePart.get("plugin"));
             Map<String, Object> depsPart = (Map<String, Object>) parts.get("gradle/rockcraft/deps");
             assertTrue(depsPart.containsKey("override-build"));
         }

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/rockcraft.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/rockcraft.in
@@ -2,7 +2,7 @@ base: ubuntu@24.04
 
 parts:
     gradle/rockcraft/runtime:
-        plugin: nil
+        plugin: jlink
         override-build: "echo ok"
     gradle/rockcraft/dump:
         plugin: nil

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/JLinkRuntimePart.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/JLinkRuntimePart.java
@@ -47,7 +47,6 @@ public class JLinkRuntimePart implements IRuntimeProvider {
         }
         HashMap<String, Object> part = new HashMap<String, Object>();
         part.put("build-packages", new String[]{options.getBuildPackage()});
-        part.put("multi-release", options.getTargetRelease());
         part.put("after", new String[]{"gradle/rockcraft/dump", "gradle/rockcraft/deps"});
         part.put("plugin", "jlink");
         part.put("jlink-jars", relativeJars);

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RawRuntimePart.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RawRuntimePart.java
@@ -64,6 +64,7 @@ public class RawRuntimePart implements IRuntimeProvider {
         append(commands,
                 "(cd ${CRAFT_PART_BUILD}/tmp && for jar in ${PROCESS_JARS}; do jar xvf ${jar}; done;)"
         );
+        append(commands, "CPATH=");
         append(commands, "for file in $(find \"${CRAFT_PART_BUILD}/tmp\" -type f -name \"*.jar\"); do");
         append(commands, "  CPATH=\"$CPATH:${file}\"");
         append(commands, "done");

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RawRuntimePart.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RawRuntimePart.java
@@ -64,13 +64,16 @@ public class RawRuntimePart implements IRuntimeProvider {
         append(commands,
                 "(cd ${CRAFT_PART_BUILD}/tmp && for jar in ${PROCESS_JARS}; do jar xvf ${jar}; done;)"
         );
-        append(commands, "CPATH=$(find ${CRAFT_PART_BUILD}/tmp -type f -name *.jar)");
-        append(commands, "CPATH=$(CPATH):$(find ${CRAFT_STAGE} -type f -name *.jar)");
-        append(commands, "CPATH=$(echo ${CPATH}:. | sed s'/[[:space:]]/:/'g)");
+        append(commands, "for file in $(find \"${CRAFT_PART_BUILD}/tmp\" -type f -name \"*.jar\"); do");
+        append(commands, "  CPATH=\"$CPATH:${file}\"");
+        append(commands, "done");
+        append(commands, "for file in $(find \"${CRAFT_STAGE}\" -type f -name \"*.jar\"); do");
+        append(commands, "  CPATH=\"$CPATH:${file}\"");
+        append(commands, "done");
         append(commands, "echo ${CPATH}");
         append(commands, "if [ \"x${PROCESS_JARS}\" != \"x\" ]; then");
-        append(commands, "  deps=$(jdeps --class-path=${CPATH} -q --recursive  --ignore-missing-deps \\");
-        append(commands, String.format("  --print-module-deps --multi-release %d ${PROCESS_JARS}); else deps=java.base; fi", options.getTargetRelease()));
+        append(commands, "  deps=$(jdeps --print-module-deps -q --recursive --ignore-missing-deps \\");
+        append(commands, String.format("  --multi-release %d --class-path=${CPATH} ${PROCESS_JARS}); else deps=java.base; fi", options.getTargetRelease()));
         append(commands, "INSTALL_ROOT=${CRAFT_PART_INSTALL}/${JAVA_HOME}");
         append(commands,
                 "rm -rf ${INSTALL_ROOT} && jlink --add-modules ${deps} --output ${INSTALL_ROOT}"

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
@@ -19,7 +19,7 @@ package com.canonical.rockcraft.builder;
 public class RockcraftOptions extends CommonRockcraftOptions {
 
     private int targetRelease = 21;
-    private boolean jlink = false;
+    private boolean jlink = true;
     private String command = "";
     private boolean createService = true;
 

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/RawRunimePartTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/RawRunimePartTest.java
@@ -60,11 +60,12 @@ public class RawRunimePartTest {
     @Test
     void rawRuntimeMultipleJars() {
         RockcraftOptions options = new RockcraftOptions();
+        options.setJlink(false);
         RawRuntimePart part = new RawRuntimePart(options);
         Map<String, Object> code = part.getRuntimePart(input);
         // classpath should contain both embeeded jars from the boot jar and every jar found in the jar directory
         // to avoid building incomplete runtime if the dependencies are packaged separately
-        assertTrue(code.get("override-build").toString().contains("CPATH=$(find ${CRAFT_PART_BUILD}/tmp -type f -name *.jar)"));
-        assertTrue(code.get("override-build").toString().contains("CPATH=$(CPATH):$(find ${CRAFT_STAGE} -type f -name *.jar)"));
+        assertTrue(code.get("override-build").toString().contains("for file in $(find \"${CRAFT_PART_BUILD}/tmp\" -type f -name \"*.jar\"); do"));
+        assertTrue(code.get("override-build").toString().contains("for file in $(find \"${CRAFT_STAGE}\" -type f -name \"*.jar\"); do"));
     }
 }


### PR DESCRIPTION
JLink plugin is now part of rockcraft and is enabled by default.

Updated RawRuntimePart codegeneration (copy paste from jlink plugin implementation)

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
