### PR TITLE
fix: do not print quotes in the platform.<architecture> tag

### DIFF
--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/AbstractRockCrafter.java
@@ -45,9 +45,9 @@ public abstract class AbstractRockCrafter {
     protected Map<String, Object> getPlatforms() {
         HashMap<String, Object> arches = new HashMap<>();
         for (RockArchitecture a : getOptions().getArchitectures())
-            arches.put(String.valueOf(a), "");
+            arches.put(String.valueOf(a), new YamlFactory.Empty());
         if (arches.isEmpty())
-            arches.put("amd64", "");
+            arches.put("amd64", new YamlFactory.Empty());
         return arches;
     }
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import com.canonical.rockcraft.util.MapMerger;
@@ -60,9 +59,7 @@ public class BuildRockCrafter extends AbstractRockCrafter {
         writeResourceFiles();
 
         BuildRockcraftOptions buildOptions = (BuildRockcraftOptions) getOptions();
-        DumperOptions dumperOptions = new DumperOptions();
-        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        Yaml yaml = new Yaml(dumperOptions);
+        Yaml yaml = YamlFactory.createYaml();
 
         Map<String, Object> commonSection = createCommonSection();
         String name = (String)commonSection.get("name");

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockBuilder.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockBuilder.java
@@ -57,7 +57,7 @@ public class RockBuilder {
      */
     @SuppressWarnings("unchecked")
     public static void pushRock(RockProjectSettings settings, CommonRockcraftOptions options) throws InterruptedException, IOException {
-        Yaml yaml = new Yaml();
+        Yaml yaml = YamlFactory.createYaml();
         Map<String, Object> rockcraft = yaml.load(new FileReader(settings.getRockOutput().resolve(IRockcraftNames.ROCKCRAFT_YAML).toFile()));
         String imageName = String.valueOf(rockcraft.get(IRockcraftNames.ROCKCRAFT_NAME));
         String imageVersion = String.valueOf(rockcraft.get(IRockcraftNames.ROCKCRAFT_VERSION));

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockCrafter.java
@@ -14,7 +14,6 @@
 package com.canonical.rockcraft.builder;
 
 import com.canonical.rockcraft.util.MapMerger;
-import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.*;
@@ -68,9 +67,7 @@ public class RockCrafter extends AbstractRockCrafter {
 
         Map<String, Object> rockcraft = createCommonSection();
 
-        DumperOptions dumperOptions = new DumperOptions();
-        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        Yaml yaml = new Yaml(dumperOptions);
+        Yaml yaml = YamlFactory.createYaml();
 
         Map<String, Object> rockcraftYaml = loadRockcraftSnippet(yaml);
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/YamlFactory.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/YamlFactory.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * Creates Yaml instance with pre-configured output style
+ */
+public abstract class YamlFactory {
+
+    /**
+     * Tag class for the empty value
+     */
+    public static class Empty {
+    }
+
+    /**
+     * Representer class to provide special formatting
+     */
+    private static class NullRepresenter extends Representer {
+        public NullRepresenter(DumperOptions options) {
+            super(options);
+            this.multiRepresenters.put(Empty.class, new RepresentMap() {
+                @Override
+                public org.yaml.snakeyaml.nodes.Node representData(Object data) {
+                        return representScalar(Tag.NULL, ""); // Represent as a scalar with no value
+                }
+            });
+        }
+    }
+
+    /**
+     * Creates a pre-configured Yaml instance
+     * @return yaml
+     */
+    public static Yaml createYaml() {
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        NullRepresenter representer = new NullRepresenter(dumperOptions);
+        return new Yaml(representer, dumperOptions);
+    }
+}

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/YamlSerializerTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/YamlSerializerTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2025 Canonical Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.canonical.rockcraft.builder;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class YamlSerializerTest {
+    @Test
+    public void testEmptyValue() {
+        Yaml yaml = YamlFactory.createYaml();
+        HashMap<Object, Object> test = new HashMap<>();
+        test.put("key", new YamlFactory.Empty());
+        assertEquals("key:\n", yaml.dump(test));
+    }
+}


### PR DESCRIPTION
Rocks fail to build due to the syntax error in the generated rockcraft.yaml - the platform tag expects
```
platform:
   amd64:
```
but snakeyaml instead outputs

```
platform:
   amd64: ''
``

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
