### PR TITLE
fix: fix command for running the rock

### DIFF
--- a/examples/maven/spring-boot-app/README.md
+++ b/examples/maven/spring-boot-app/README.md
@@ -22,7 +22,7 @@ This will build the rock image and push it to the local docker daemon
 
 Run the application:
 
-`docker run spring-boot-app-sample exec /usr/bin/java -jar jars/spring-boot-app-sample-0.0.1-SNAPSHOT.jar`
+`docker run spring-boot-app-sample exec /usr/bin/java -jar /jars/spring-boot-app-sample-0.0.1-SNAPSHOT.jar`
 
 This will output:
 


### PR DESCRIPTION
Add missing '/' in the run command for https://github.com/rockcrafters/java-rockcraft-plugins/issues/101

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
