### PR TITLE
feat: add distTask option to make create-rock optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,20 @@ The generated `rockraft.yaml` can be overridden by providing `rockcraftYaml` con
 
 # Configuration Options
 
-|Name|Description|
-|----|-----------|
-|buildPackage| OpenJDK Ubuntu package used to create a runtime image, e.g. `openjdk-21-jdk-headless`|
-|targetRelease| `--multi-release` option passed to `jlink` |
-|summary| rock image summary, e.g. `Spring Boot Application` |
-|description| path to the description file, e.g. `README.md` |
-|command| command used for the startup service |
-|source | Git URL of `chisel-releases` repository |
-|branch| Git branch of `chisel-releases` repository
-|architectures| list of the supported architectures, e.g. `amd64, arm64` |
-|slices| list of additional [chisel](https://github.com/canonical/chisel) slices to install |
-|rockcraftYaml| path to `rockcraft.yaml` with the overrides for the generated `rockraft.yaml`
-|createService| create startup service (default true) |
+| Name          | Description                                                                                           |
+|---------------|-------------------------------------------------------------------------------------------------------|
+| buildPackage  | OpenJDK Ubuntu package used to create a runtime image, e.g. `openjdk-21-jdk-headless`                 |
+| targetRelease | `--multi-release` option passed to `jlink`                                                            |
+| summary       | rock image summary, e.g. `Spring Boot Application`                                                    |
+| description   | path to the description file, e.g. `README.md`                                                        |
+| command       | command used for the startup service                                                                  |
+| source        | Git URL of `chisel-releases` repository                                                               |
+| branch        | Git branch of `chisel-releases` repository                                                            
+| architectures | list of the supported architectures, e.g. `amd64, arm64`                                              |
+| slices        | list of additional [chisel](https://github.com/canonical/chisel) slices to install                    |
+| rockcraftYaml | path to `rockcraft.yaml` with the overrides for the generated `rockraft.yaml`                         
+| createService | create startup service (default true)                                                                 |
+| distTask      | task/goal that creates application distribution that can be deployed to the container (default empty) |
 
 # Gradle Plugin
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The generated `rockraft.yaml` can be overridden by providing `rockcraftYaml` con
 | description   | path to the description file, e.g. `README.md`                                                        |
 | command       | command used for the startup service                                                                  |
 | source        | Git URL of `chisel-releases` repository                                                               |
-| branch        | Git branch of `chisel-releases` repository                                                            
+| branch        | Git branch of `chisel-releases` repository                                                            |
 | architectures | list of the supported architectures, e.g. `amd64, arm64`                                              |
 | slices        | list of additional [chisel](https://github.com/canonical/chisel) slices to install                    |
-| rockcraftYaml | path to `rockcraft.yaml` with the overrides for the generated `rockraft.yaml`                         
+| rockcraftYaml | path to `rockcraft.yaml` with the overrides for the generated `rockraft.yaml`                         |
 | createService | create startup service (default true)                                                                 |
 | distTask      | task/goal that creates application distribution that can be deployed to the container (default empty) |
 
@@ -220,9 +220,9 @@ Apply the plugin:
                         </goals>
                     </execution>
                 </executions>
-            <plugin>
+            </plugin>
         </plugins>
-    <build>
+    </build>
 ```
 ### 2. Configure the container
 

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockcraftOptions.java
@@ -22,6 +22,7 @@ public class RockcraftOptions extends CommonRockcraftOptions {
     private boolean jlink = true;
     private String command = "";
     private boolean createService = true;
+    private String distTask;
 
     /**
      * Construct RockcraftOptions
@@ -101,6 +102,22 @@ public class RockcraftOptions extends CommonRockcraftOptions {
      */
     public void setCreateService(boolean createService) {
         this.createService = createService;
+    }
+
+    /**
+     * Get deployment task/goal
+     * @return deployment task after which the create-rock should be executed
+     */
+    public String getDistTask() {
+        return distTask;
+    }
+
+    /**
+     * Set deployment task/goal
+     * @param distTask - deployment task/goal, e.g. jar
+     */
+    public void setDistTask(String distTask) {
+        this.distTask = distTask;
     }
 
 }


### PR DESCRIPTION
Add distTask option for gradle plugin.
-  Make `build-rock` task depend on `check` instead of being the `build` finalizer. 
-  Make `create-rock` task optional - emit a warning instead of hard error if the task can not be configured.
- Update documentation and fix mismatched tags

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
-----
