### PR TITLE
fix: use artifact id for maven rock name

### DIFF
--- a/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
+++ b/rockcraft-maven/src/main/java/com/canonical/rockcraft/maven/RockSettingsFactory.java
@@ -53,7 +53,7 @@ public class RockSettingsFactory {
      * @return RockProjectSettings
      */
     public static final RockProjectSettings createBuildRockProjectSettings(RuntimeInformation info, MavenProject project) {
-        return new RockProjectSettings(BuildSystem.maven, info.getMavenVersion(), project.getName(),
+        return new RockProjectSettings(BuildSystem.maven, info.getMavenVersion(), project.getArtifactId(),
                 project.getVersion(), project.getBasedir().getAbsoluteFile().toPath(),
                 Paths.get(project.getBuild().getDirectory(), IRockcraftNames.BUILD_ROCK_OUTPUT),
                 false);

--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockNameUtil.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/RockNameUtil.java
@@ -13,7 +13,6 @@
  */
 package com.canonical.rockcraft.builder;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -24,6 +23,7 @@ import java.util.regex.Pattern;
 public class RockNameUtil {
     /**
      * Formats name according to rockcraft rules
+     *
      * @param name - project name
      * @return formatted rock name
      */
@@ -31,13 +31,13 @@ public class RockNameUtil {
         if (name == null) {
             throw new RuntimeException("Rock name can not be null");
         }
-        String rockName = name.toLowerCase()
-                .replace('-', ' ') // replace '-' with ' ' to string leading and trailing hyphens
+        String rockName = name.toLowerCase().replace('-', ' ') // replace '-' with ' ' to strip leading and trailing hyphens
                 .trim() // trim to remove leading or trailing spaces
                 .replace(' ', '-') // replace any spaces with hyphens
                 .replaceAll("-+", "-"); // replace duplicate hyphens with a single one
+        rockName = rockName.substring(0, Math.min(rockName.length(), 40)); // trim length to 40 symbols
         if (!Pattern.compile("^[a-z0-9-]+$").matcher(rockName).matches()) {
-            throw new RuntimeException("Unable to create name for the rock from "+ name + ". Please use custom rockcraft.yaml");
+            rockName = "rock";
         }
         return rockName;
     }

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/RockNameUtilTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/RockNameUtilTest.java
@@ -16,21 +16,28 @@ package com.canonical.rockcraft.builder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RockNameUtilTest {
 
     @Test
-    public void testFormatRockName(){
+    public void testFormatRockName() {
         assertEquals("test", RockNameUtil.formatRockName("test"));
         assertEquals("test", RockNameUtil.formatRockName("TesT"));
-        assertEquals("test", RockNameUtil.formatRockName(" TesT "));
         assertEquals("test", RockNameUtil.formatRockName(" TesT "));
         assertEquals("te-st", RockNameUtil.formatRockName("Te  sT"));
         assertEquals("te-st", RockNameUtil.formatRockName("Te-  sT"));
         assertEquals("te-st", RockNameUtil.formatRockName("Te-  -sT"));
         assertEquals("te-st", RockNameUtil.formatRockName("-Te-  -sT"));
         assertEquals("te-st", RockNameUtil.formatRockName("-Te-  -sT-"));
-        assertThrows(RuntimeException.class, () ->RockNameUtil.formatRockName("-Te- ! -sT") );
+        assertEquals("rock", RockNameUtil.formatRockName("-Te- ! -sT"));
+    }
+
+    @Test
+    public void testRockNameLength() {
+        StringBuilder name = new StringBuilder();
+        for (int i = 0; i < 5; ++i) {
+            name.append("0123456789");
+        }
+        assertEquals(40, RockNameUtil.formatRockName(name.toString()).length());
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/rockcrafters/java-rockcraft-plugins/issues/111

Gradle uses project name which translates to the artifact id of the output. Maven was using display name which does not map well into rock name. Artifact ids has same constraints as rock names:
https://maven.apache.org/guides/mini/guide-naming-conventions.html only characters, digits and hyphens are allowed. There is no 40 character size constraint.

Changes:
 - use artifact id for the maven rock name
 - truncate rock name to 40 symbols
 - Keep name sanitiser
 - Return "rock" instead of the exception if the name can not be sanitised.

This addresses:
https://github.com/rockcrafters/java-rockcraft-plugins/issues/109

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
