### PR TITLE
fix: export transitive dependencies in maven build rock

### DIFF
--- a/rockcraft-maven/pom.xml
+++ b/rockcraft-maven/pom.xml
@@ -46,11 +46,6 @@
     <artifactId>rockcraft-maven-plugin</artifactId>
     <dependencies>
         <dependency>
-            <groupId>org.twdata.maven</groupId>
-            <artifactId>mojo-executor</artifactId>
-            <version>2.4.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${mavenPluginVersion}</version>
@@ -62,6 +57,12 @@
             <version>${maven-plugin-tools.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+
         <!-- Maven -->
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/rockcraft-maven/src/it/build-rock/pom.xml
+++ b/rockcraft-maven/src/it/build-rock/pom.xml
@@ -13,6 +13,11 @@
             <artifactId>mojo-executor</artifactId>
             <version>2.4.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.8.1</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${project.basedir}/target</directory>

--- a/rockcraft-maven/src/it/build-rock/verify.bsh
+++ b/rockcraft-maven/src/it/build-rock/verify.bsh
@@ -17,3 +17,9 @@ if ( ! dependency.exists() )
 {
     throw new FileNotFoundException( "Declared dependency artifact was not copied: " + rockcraftPlugin.getAbsolutePath() );
 }
+
+File dependency = new File( basedir.getAbsolutePath() +"/target/build-rock/dependencies/org/apache/commons/commons-lang3");
+if ( ! dependency.exists() )
+{
+    throw new FileNotFoundException( "Transitive dependency artifact (maven-resolver-plugin -> commons-lang3) was not copied: " + rockcraftPlugin.getAbsolutePath() );
+}


### PR DESCRIPTION
The implementation was calling model.getDependencies() which returned only direct dependencies of the project. Inherit from GoOffline mojo of Maven Dependency Plugin to retrieve full list of the dependencies.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
