### PR TITLE
fix(gradle): fix typo in gradle build script

### DIFF
--- a/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/builder/BuildRockCrafter.java
@@ -171,6 +171,7 @@ public class BuildRockCrafter extends AbstractRockCrafter {
 
     private String replaceMacros(String content) {
         HashMap<String, String> replacements = new HashMap<>();
+        replacements.put("gradle-user-home", "export GRADLE_USER_HOME=${WORKDIR}/.gradle");
         replacements.put("goal",
                 Arrays.stream(((BuildRockcraftOptions) getOptions()).getBuildGoals()).
                         collect(Collectors.joining(" ")));

--- a/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
+++ b/rockcraft/src/test/java/com/canonical/rockcraft/builder/BuildRockCrafterTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -61,16 +62,25 @@ public class BuildRockCrafterTest {
             assertTrue(parts.containsKey("maven-cache"));
             assertTrue(parts.containsKey("build-tool"));
         }
-        Path buildFile = tempDir.toPath().resolve("build-maven.sh");
+        String result = readFile("build-maven.sh");
+        assertTrue(result.contains("GOAL=package"), "Goals should be replaced");
+        assertFalse(result.contains("!!"));
+
+        result = readFile("build-gradle.sh");
+        assertFalse(result.contains("!!"));
+
+        assertTrue(true, "The build should succeed");
+    }
+
+    private String readFile(String file) throws IOException {
+        Path buildFile = tempDir.toPath().resolve(file);
+        StringBuilder result = new StringBuilder();
         try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(buildFile.toFile())))) {
-            StringBuilder result = new StringBuilder();
             String line;
             while ((line = r.readLine())!= null){
                 result.append(line);
             }
-            assertTrue(result.toString().contains("GOAL=package"), "Goals should be replaced");
         }
-
-        assertTrue(true, "The build should succeed");
+        return result.toString();
     }
 }


### PR DESCRIPTION
Substitution macro for gradle user home in gradle build script did not have a matching replacer value. Added replacer value and updated test.

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
