### PR TITLE
Revert "chore(deps): update plugin com.gradleup.shadow to v9.0.2"

### DIFF
--- a/rockcraft-gradle/build.gradle.kts
+++ b/rockcraft-gradle/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.gradleup.shadow") version "9.0.2"
+    id("com.gradleup.shadow") version "9.0.1"
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "1.3.1"
     id ("org.gradlex.reproducible-builds") version "1.0"


### PR DESCRIPTION
Reverts rockcrafters/java-rockcraft-plugins#139 - The updated version requires Java 11