### PR TITLE
chore: rollback gradlup shadow plugin to version 8

### DIFF
--- a/rockcraft-gradle/build.gradle.kts
+++ b/rockcraft-gradle/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.gradleup.shadow") version "9.0.2"
+    id("com.gradleup.shadow") version "8.3.8"
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "1.3.1"
     id ("org.gradlex.reproducible-builds") version "1.0"


### PR DESCRIPTION
version 9 of the plugin requires a minimum Java version 11

- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
