### PR TITLE
feat: add openjdk-25 to the supported list.

### DIFF
--- a/rockcraft/src/main/java/com/canonical/rockcraft/util/ToolchainHelper.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/util/ToolchainHelper.java
@@ -12,7 +12,7 @@ public final class ToolchainHelper {
     public static final String OPENJDK_8 = "openjdk-8-jdk";
     public static final String OPENJDK_8_HEADLESS = "openjdk-8-jdk-headless";
     public static final String DEFAULT_JDK = "openjdk-21-jdk-headless";
-    private static final HashSet<String> SUPPORTED = new HashSet<>(Arrays.asList("11", "17", "21"));
+    private static final HashSet<String> SUPPORTED = new HashSet<>(Arrays.asList("11", "17", "21", "25"));
 
     private ToolchainHelper() {}
 


### PR DESCRIPTION
OpenJDK 25 slices were merged in chisel releases. Add openjdk-25 as a supported chisel toolchain

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
