### PR TITLE
fix: maven artifact copy - skip existing files

### DIFF
--- a/rockcraft/src/main/java/com/canonical/rockcraft/util/MavenArtifactCopy.java
+++ b/rockcraft/src/main/java/com/canonical/rockcraft/util/MavenArtifactCopy.java
@@ -75,6 +75,10 @@ public class MavenArtifactCopy {
         Path outputLocation = getDestinationPath(group, name, version);
         outputLocation.toFile().mkdirs();
         Path destinationFile = outputLocation.resolve(f.getName());
+        if (Files.exists(destinationFile)) {
+            // skip existing files, maven repository is read-only
+            return;
+        }
         Files.copy(f.toPath(), destinationFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
         writeDigest(destinationFile);
     }


### PR DESCRIPTION
Speeds up dependency export task by skipping existing artifact files

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
