### PR TITLE
fix: intercept POM lookups to export BOMs for detached plugin configurations

### DIFF
--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/dependencies/BomResolutionListener.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/dependencies/BomResolutionListener.java
@@ -1,0 +1,36 @@
+package com.canonical.rockcraft.gradle.dependencies;
+
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyArtifact;
+import org.gradle.api.artifacts.DependencyResolutionListener;
+import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class BomResolutionListener implements DependencyResolutionListener {
+    private final Set<ComponentIdentifier> boms = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public void beforeResolve(ResolvableDependencies dependencies) {
+        for (Dependency dep : dependencies.getDependencies()) {
+            if (!(dep instanceof ExternalModuleDependency)) continue;
+            for (DependencyArtifact artifact : ((ExternalModuleDependency) dep).getArtifacts()) {
+                if (!"pom".equals(artifact.getType()))
+                    continue;
+                boms.add(DefaultModuleComponentIdentifier.newId(
+                        DefaultModuleIdentifier.newId(dep.getGroup(), dep.getName()),
+                        dep.getVersion()));
+            }
+        }
+    }
+
+    @Override
+    public void afterResolve(ResolvableDependencies dependencies) { }
+
+    public Set<ComponentIdentifier> getBoms() { return boms; }
+}

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/dependencies/DependencyExportTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/dependencies/DependencyExportTask.java
@@ -146,7 +146,7 @@ public abstract class DependencyExportTask extends DefaultTask {
                         // copy unresolved boms to maven cache
                         HashSet<ComponentIdentifier> unresolvedBoms = new HashSet<>();
                         dependencies.getDependencyManagement().stream().filter(x -> !dependencyManagementResolved.contains(x)).forEach(unresolvedBoms::add);
-                        copyBoms(configurations, handler, artifactCopy, unresolvedBoms);
+                        copyBoms(handler, artifactCopy, unresolvedBoms);
                         copyExtraFiles(configurations, artifactCopy, unresolvedBoms);
                         dependencyManagementResolved.addAll(dependencies.getDependencyManagement());
                     }
@@ -181,7 +181,7 @@ public abstract class DependencyExportTask extends DefaultTask {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private void copyBoms(ConfigurationContainer configurations, DependencyHandler handler, ArtifactCopy artifactCopy, Set<ComponentIdentifier> componentIdentifiers) throws IOException {
+    private void copyBoms( DependencyHandler handler, ArtifactCopy artifactCopy, Set<ComponentIdentifier> componentIdentifiers) throws IOException {
         ArtifactResolutionResult artifacts = handler.createArtifactResolutionQuery().forComponents(componentIdentifiers).withArtifacts(MavenModule.class, new Class[]{MavenPomArtifact.class}).execute();
         for (ComponentArtifactsResult component : artifacts.getResolvedComponents()) {
             if (component.getId() instanceof ModuleComponentIdentifier) {
@@ -202,23 +202,33 @@ public abstract class DependencyExportTask extends DefaultTask {
     public void export() throws IOException {
         Path outputLocationRoot = getOutputDirectory().getAsFile().get().toPath();
         ArtifactCopy artifactCopy = new ArtifactCopy(outputLocationRoot);
-        if (dependencyOptions.getConfigurations() != null && dependencyOptions.getConfigurations().length > 0) {
-            for (String configName : dependencyOptions.getConfigurations()) {
-                Configuration config = getProject().getConfigurations().findByName(configName);
-                if (config == null)
-                    throw new IllegalArgumentException(String.format("Configuration %s was not found", configName));
-                exportConfiguration(config, artifactCopy);
-            }
-            if (dependencyOptions.isBuildScript()) {
+        BomResolutionListener listener = new BomResolutionListener();
+        try {
+            getProject().getGradle().addListener(listener);
+            if (dependencyOptions.getConfigurations() != null && dependencyOptions.getConfigurations().length > 0) {
+                for (String configName : dependencyOptions.getConfigurations()) {
+                    Configuration config = getProject().getConfigurations().findByName(configName);
+                    if (config == null)
+                        throw new IllegalArgumentException(String.format("Configuration %s was not found", configName));
+                    exportConfiguration(config, artifactCopy);
+                }
+                if (dependencyOptions.isBuildScript()) {
+                    exportBuildScript(artifactCopy);
+                    exportSettings(artifactCopy);
+                }
+            } else {
+                for (Configuration config : getProject().getConfigurations()) {
+                    exportConfiguration(config, artifactCopy);
+                }
                 exportBuildScript(artifactCopy);
                 exportSettings(artifactCopy);
             }
-        } else {
-            for (Configuration config : getProject().getConfigurations()) {
-                exportConfiguration(config, artifactCopy);
-            }
-            exportBuildScript(artifactCopy);
-            exportSettings(artifactCopy);
+            // this writes BOMs looked up by the plugins,
+            // e.g. spring dependency-management plugin
+            copyBoms(getProject().getDependencies(), artifactCopy, listener.getBoms());
+        }
+        finally {
+            getProject().getGradle().removeListener(listener);
         }
     }
 }

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/DependencyExportTest.java
@@ -107,4 +107,14 @@ public class DependencyExportTest extends BaseRockcraftTest {
         Path pluginJar = projectDir.toPath().resolve("build/" + IRockcraftNames.BUILD_ROCK_OUTPUT + "/" + IRockcraftNames.DEPENDENCIES_ROCK_OUTPUT + "/io/gitlab/plunts/plantuml-gradle-plugin/2.0.0/plantuml-gradle-plugin-2.0.0.jar");
         assertTrue(pluginJar.toFile().exists(), "Plugin JAR is downloaded");
     }
+
+    @Test
+    public void testExportSpringDependencyManagementBom() throws IOException {
+        writeString(getBuildFile(), getResource("dependencies-spring-dm.in"));
+        BuildResult result = runBuild("dependencies-export", "--stacktrace");
+        assertEquals(TaskOutcome.SUCCESS, getLastTaskOutcome(result)); // the build needs to succeed
+
+        Path bomPom = projectDir.toPath().resolve("build/" + IRockcraftNames.BUILD_ROCK_OUTPUT + "/" + IRockcraftNames.DEPENDENCIES_ROCK_OUTPUT + "/org/springframework/boot/spring-boot-dependencies/3.3.4/spring-boot-dependencies-3.3.4.pom");
+        assertTrue(bomPom.toFile().exists(), "spring-boot-dependencies BOM POM is exported");
+    }
 }

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/dependencies-spring-dm.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/dependencies-spring-dm.in
@@ -11,6 +11,5 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/dependencies-spring-dm.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/dependencies-spring-dm.in
@@ -1,0 +1,16 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
+    id 'io.github.rockcrafters.rockcraft'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}


### PR DESCRIPTION
spring dependency-management plugin uses detached configuration to resolve dependencies. 

When building `examples/devcontainer` the build in container with 
```
 docker run -v `pwd`:`pwd` --user $(id -u):$(id -g) --env PEBBLE=/tmp build-devpack-for-spring-cli:latest exec build `pwd` --no-daemon 
```
fails because the build is unable to resolve `spring-boot-starter` artifact because `spring-boot-dependencies` is missing.

```
2026-07-26T23:07:12.412+0000 [DEBUG] [org.gradle.api.internal.artifacts.ivyservice.modulecache.ResolvedArtifactCaches] Reusing in-memory cache for repo 'InsecureRemove' [a5e41e195acf0505b47a31c4c2867283].
2026-07-26T23:07:12.413+0000 [DEBUG] [org.gradle.api.internal.artifacts.ivyservice.ivyresolve.RepositoryChainComponentMetaDataResolver] Attempting to resolve component for org.springframework.boot:spring-boot-dependencies:3.3.4 using repositories [maven, MavenLocal, InsecureRemove]
2026-07-26T23:07:12.413+0000 [DEBUG] [org.gradle.api.internal.artifacts.repositories.resolver.DefaultExternalResourceArtifactResolver] Loading file:/home/ubuntu/.m2/repository/org/springframework/boot/spring-boot-dependencies/3.3.4/spring-boot-dependencies-3.3.4.pom
2026-07-26T23:07:12.413+0000 [DEBUG] [org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceResolver] No meta-data file or artifact found for module 'org.springframework.boot:spring-boot-dependencies:3.3.4' in repository 'maven'.
2026-07-26T23:07:12.413+0000 [DEBUG] [org.gradle.api.internal.artifacts.ivyservice.modulecache.PersistentModuleMetadataCache] Recording absence of module descriptor in cache: org.springframework.boot:spring-boot-dependencies:3.3.4 [changing = false]
2026-07-26T23:07:12.413+0000 [DEBUG] [org.gradle.api.internal.artifacts.ivyservice.ivyresolve.CachingModuleComponentRepository] Detected non-existence of module 'org.springframework.boot:spring-boot-dependencies:3.3.4' in resolver cache 'MavenLocal'
2026-07-26T23:07:12.413+0000 [DEBUG] [org.gradle.api.internal.artifacts.ivyservice.ivyresolve.CachingModuleComponentRepository] Detected non-existence of module 'org.springframework.boot:spring-boot-dependencies:3.3.4' in resolver cache 'InsecureRemove'
```

This change adds a global listener for the dependency export duration to intercept additional dependency resolution done by plugins

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
