### PR TITLE
feat: skip rockcraft tasks if rockcraft is not found

### DIFF
--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/CreateBuildRockcraftTask.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/CreateBuildRockcraftTask.java
@@ -48,7 +48,7 @@ public abstract class CreateBuildRockcraftTask extends DefaultTask {
         super();
         this.options = options;
         if (options.getBuildGoals().length == 0) {
-            options.setBuildGoals(new String[]{"build", "-x", ITaskNames.CHECK_ROCKCRAFT});
+            options.setBuildGoals(new String[]{"build"});
         }
     }
 

--- a/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockcraftPlugin.java
+++ b/rockcraft-gradle/src/main/java/com/canonical/rockcraft/gradle/RockcraftPlugin.java
@@ -41,6 +41,7 @@ import java.util.Set;
  */
 public class RockcraftPlugin implements Plugin<Project> {
 
+    public static final String HAS_ROCKCRAFT = "io.github.rockcrafters.rockcraft.has_rockcraft";
     private final Logger logger = Logging.getLogger(RockcraftPlugin.class);
 
     /**
@@ -98,22 +99,25 @@ public class RockcraftPlugin implements Plugin<Project> {
                 .register(ITaskNames.PUSH_BUILD_ROCK, PushBuildRockcraftTask.class, buildOptions);
         project.getTasks()
                 .getByName(ITaskNames.PUSH_BUILD_ROCK)
-                .dependsOn(project.getTasksByName(ITaskNames.BUILD_BUILD_ROCK, false));
+                .dependsOn(project.getTasksByName(ITaskNames.BUILD_BUILD_ROCK, false))
+                .onlyIf(task -> hasRockcraft(project));
 
 
         TaskProvider<Task> checkTask = project.getTasks().register(ITaskNames.CHECK_ROCKCRAFT, s -> {
             s.doFirst(x -> {
                 try {
                     RockBuilder.checkRockcraft();
+                    project.getExtensions().getExtraProperties().set(HAS_ROCKCRAFT, true);
                 } catch (IOException | InterruptedException e) {
-                    throw new UnsupportedOperationException(e.getMessage());
+                    logger.warn(e.getMessage());
                 }
             });
         });
 
         project.getTasks()
                 .getByName(ITaskNames.BUILD_BUILD_ROCK)
-                .dependsOn(checkTask);
+                .dependsOn(checkTask)
+                .onlyIf(task -> hasRockcraft(project));
 
         Set<Task> tasks;
         String deploymentTask = options.getDistTask();
@@ -142,17 +146,27 @@ public class RockcraftPlugin implements Plugin<Project> {
         TaskProvider<CreateRockcraftTask> create = project.getTasks().register(ITaskNames.CREATE_ROCK, CreateRockcraftTask.class, options);
 
         project.getTasks().getByName(ITaskNames.PUSH_ROCK)
-                .dependsOn(build);
+                .dependsOn(build)
+                .onlyIf(task -> hasRockcraft(project));
 
         project.getTasks().getByName(ITaskNames.BUILD_ROCK)
                 .dependsOn(create)
-                        .dependsOn(checkTask);
+                        .dependsOn(checkTask)
+                        .onlyIf(task -> hasRockcraft(project));
 
         project.getTasks().getByName(ITaskNames.BUILD_ROCK)
                 .dependsOn(create);
 
         project.getTasks().getByName(ITaskNames.CREATE_ROCK)
                 .dependsOn(tasks);
+    }
+
+    private boolean hasRockcraft(Project project) {
+        return Boolean.TRUE.equals(project
+                .getExtensions()
+                .getExtraProperties()
+                .getProperties()
+                .get(HAS_ROCKCRAFT));
     }
 
     private boolean isNativeCompile(Project project) {

--- a/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
+++ b/rockcraft-gradle/src/test/java/com/canonical/rockcraft/gradle/CreateBuildRockTest.java
@@ -132,4 +132,11 @@ public class CreateBuildRockTest extends BaseRockcraftTest {
             assertEquals("openjdk-17-jdk-headless", packages.get(0));
         }
     }
+
+    @Test
+    public void testBuildBuildRockSkippedWithoutRockcraftProperty() throws IOException {
+        writeString(getBuildFile(), getResource("build-build-rock-no-rockcraft.in"));
+        BuildResult result = runBuild(ITaskNames.BUILD_BUILD_ROCK, "--stacktrace");
+        assertEquals(TaskOutcome.SKIPPED, result.task(":" + ITaskNames.BUILD_BUILD_ROCK).getOutcome());
+    }
 }

--- a/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/build-build-rock-no-rockcraft.in
+++ b/rockcraft-gradle/src/test/resources/com/canonical/rockcraft/gradle/build-build-rock-no-rockcraft.in
@@ -1,0 +1,29 @@
+plugins {
+    id('application')
+    id('io.github.rockcrafters.rockcraft')
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'Test'
+    }
+}
+
+// Allow checkRockcraft to run, then clear the project property it sets so we
+// can verify build-build-rock is skipped when the property is absent.
+tasks.register('clearRockcraftProperty') {
+    dependsOn 'checkRockcraft'
+    doLast {
+        project.ext.set('io.github.rockcrafters.rockcraft.has_rockcraft', false)
+    }
+}
+
+tasks.named('build-build-rock') {
+    dependsOn 'clearRockcraftProperty'
+}

--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle-native.sh
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle-native.sh
@@ -4,7 +4,7 @@ if [ $# -gt 0 ]; then
     shift
 fi
 if [ $# -eq 0 ]; then
-    TASK="!!goal!! -x checkRockcraft"
+    TASK="!!goal!!"
 else
     TASK=$@
 fi

--- a/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle.sh
+++ b/rockcraft/src/main/resources/com/canonical/rockcraft/builder/build-gradle.sh
@@ -4,7 +4,7 @@ if [ $# -gt 0 ]; then
     shift
 fi
 if [ $# -eq 0 ]; then
-    TASK="!!goal!! -x checkRockcraft"
+    TASK="!!goal!!"
 else
     TASK=$@
 fi


### PR DESCRIPTION
This PR simplifies build and test container - it no longer depends on passing -x checkRockcraft to build in the container.

- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
